### PR TITLE
Ratchet coverage to 30, add mkdocs deploy workflow, ADR-0024 + ADR-0025

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,9 @@ source = pdip
 branch = False
 
 [report]
-fail_under = 20
+# Floor ratcheted from 20 to 30 per ADR-0023 — see the ratchet policy
+# in that ADR for the rules governing this number.
+fail_under = 30
 show_missing = True
 skip_empty = True
 skip_covered = False

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,67 @@
+# Builds the mkdocs site and publishes it to GitHub Pages on every
+# push to ``main``. The site itself is scaffolded in mkdocs.yml and
+# docs/ (see ADR-0018 / docs/index.md).
+#
+# GitHub Pages must be enabled for the repository with Source =
+# "GitHub Actions" for the publish step to succeed. Until that is
+# configured, the build step still exercises the site so a broken
+# link or misconfigured nav fails CI rather than production.
+
+name: Docs build and deploy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - '.github/workflows/docs-deploy.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build mkdocs site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install mkdocs-material
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+      - name: Build site
+        # ``--strict`` is intentionally off: ADRs cross-link to repo
+        # files (setup.py, .github/workflows/*, .coveragerc) that are
+        # not part of the docs tree. Warnings still surface in the
+        # build log; readers on GitHub see the linked files directly.
+        run: mkdocs build --site-dir _site
+      - name: Upload site artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test with unittest and coverage
         run: |
           coverage run run_tests.py
-          coverage report -m --fail-under=20
+          coverage report -m --fail-under=30
           coverage xml
           coverage html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ for the public API surface described in
 
 ### Added
 
-- Governance methodology under `docs/governance/` with 23 Architecture
+- Governance methodology under `docs/governance/` with 25 Architecture
   Decision Records documenting existing pdip decisions.
 - ADR-0017 — Python support matrix is owned by `python_requires` and
   cannot be quietly narrowed by a dependency upgrade.
@@ -32,6 +32,13 @@ for the public API surface described in
   Kafka adapter.
 - ADR-0023 — Coverage floor policy (`.coveragerc` with
   `fail_under=20` starting point and a ratchet plan).
+- ADR-0024 — Release process: semver mapping, CHANGELOG discipline,
+  tag-based PyPI publish.
+- ADR-0025 — Dependabot auto-merge policy: patch-level pinned-package
+  bumps auto-merge on green CI; minor / major / integrator-extra
+  bumps still need human review.
+- `.github/workflows/docs-deploy.yml` builds the mkdocs-material site
+  on every PR and publishes it to GitHub Pages on push to `main`.
 - `.coveragerc` at the repo root, shared between local runs and CI.
 - 17 new unit tests across Repository (9), ConfigManager env
   override (2), and `@dtoclass` decorator (6). Suite total goes
@@ -118,6 +125,8 @@ for the public API surface described in
 - Bumped `injector` 0.21.0 → 0.22.0. Changelog for 0.22 adds PEP 593
   `Annotated` support and drops Python 3.7 (not in our supported
   window, so no effect).
+- Coverage floor ratcheted from 20 to **30** per ADR-0023 (suite now
+  measures ~30 % with the new connector tests).
 - `mysql-connector-python` pin moves from `==8.4.0` to `>=9.1,<10`.
   Unblocked by ADR-0020 (Python floor raised to 3.9). mysql-connector
   9.x drops Python 3.8 support but our supported matrix no longer

--- a/docs/governance/adr/0024-release-process.md
+++ b/docs/governance/adr/0024-release-process.md
@@ -1,0 +1,165 @@
+# ADR-0024: Release process — semver, CHANGELOG, and PyPI publish
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Deciders:** pdip maintainers
+- **Tags:** release, packaging, process
+
+## Context
+
+pdip is published on PyPI as [`pdip`](https://pypi.org/project/pdip).
+Today the release process is implicit:
+
+- `setup.py` reads the version from a `PYPI_PACKAGE_VERSION`
+  environment variable, defaulting to `0.6.10`.
+- [`.github/workflows/python-upload-package.yml`](../../../.github/workflows/python-upload-package.yml)
+  and [`python-upload-test-package.yml`](../../../.github/workflows/python-upload-test-package.yml)
+  build and upload on push, but neither the tagging scheme nor the
+  mapping between code changes and version bumps is written down.
+- `CHANGELOG.md` has an **Unreleased** section but no policy on when
+  entries move into a numbered release.
+
+The last ~half year of work in this repository (ADR-0017 through
+ADR-0023) changed the public surface in meaningful ways — driver
+swaps, the Python floor raise, the CI matrix. A release that does
+not distinguish a patch fix from a Python-floor change is a trap
+for every downstream consumer.
+
+## Decision
+
+### 1. Semantic versioning maps to CHANGELOG categories
+
+pdip follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+The `CHANGELOG.md` (Keep a Changelog format) is the canonical source
+for what kind of release a given set of changes adds up to:
+
+| CHANGELOG section | Version part | Example |
+|---|---|---|
+| **Removed** with a note that existing consumers must adapt | **MAJOR** | `1.0.0`, `2.0.0` |
+| **Changed** (breaking) or new top-level feature on the public API | **MINOR** | `0.7.0`, `1.1.0` |
+| **Added** of new optional surface, **Fixed**, or no-op maintenance | **PATCH** | `0.6.11` |
+
+While pdip is on `0.x`, **MINOR** is the signal for breaking changes
+(as the semver spec allows). Once we reach `1.0`, **MAJOR** is the
+only breaking signal.
+
+Examples from recent work:
+
+- ADR-0020 (raise Python floor 3.8 → 3.9) is a **MINOR** bump on
+  `0.x`: it is breaking but while we are pre-1.0 we do not bump
+  major.
+- ADR-0021 and ADR-0022 (driver migrations) are **MINOR** bumps
+  because the extras matrix changes and third-party consumers who
+  depend on the old driver names have to edit their installs.
+- PR #53 (cryptography / Flask / Werkzeug patch and minor bumps)
+  is a **PATCH** bump: no pdip API change, transitive maintenance.
+
+### 2. Version source of truth
+
+`setup.py`'s `PYPI_PACKAGE_VERSION` env var stays. Releases happen
+by pushing a **git tag** of the form `vMAJOR.MINOR.PATCH` (e.g.
+`v0.7.0`) to `main`. The publish workflow reads the tag, strips the
+leading `v`, and sets the version.
+
+The tag is **signed** (`git tag -s`) by the releaser. Unsigned tags
+do not trigger the publish workflow. (If GPG is not set up for the
+releaser, fall back to an annotated tag with a well-known committer
+identity; treat this as a gap to close.)
+
+### 3. Release checklist
+
+When cutting a release:
+
+1. Confirm `main` is green on the full CI matrix.
+2. Move the **Unreleased** CHANGELOG block to a new section titled
+   `[MAJOR.MINOR.PATCH] — YYYY-MM-DD`. Add comparison links at the
+   bottom of the file.
+3. Bump the default in `setup.py` (`env_version = getenv(..., default='MAJOR.MINOR.PATCH')`)
+   so that tagless local builds produce a sane number.
+4. Open a PR titled `chore(release): MAJOR.MINOR.PATCH`.
+5. Once merged to `main`, tag `vMAJOR.MINOR.PATCH` and push the tag.
+6. The publish workflow uploads to PyPI and creates a GitHub
+   Release.
+
+### 4. Pre-releases and hotfixes
+
+- Pre-releases are tagged with the usual semver pre-release suffix:
+  `v0.7.0rc1`, `v0.7.0b1`. They publish to TestPyPI via
+  `python-upload-test-package.yml` only.
+- Hotfixes branch from the release tag, land as their own PR, and
+  cut a `PATCH` bump from the same branch.
+
+### 5. Yanking
+
+A broken release is yanked from PyPI with an explanatory release
+note. No new version is cut solely to replace a yanked version; the
+next legitimate bump rolls the fix in.
+
+## Consequences
+
+### Positive
+
+- Consumers can read `CHANGELOG.md` and immediately know which
+  version they need for a given fix or feature.
+- The git tag is the release boundary; there is no state in the
+  repository that contradicts it.
+- The mapping between CHANGELOG categories and version parts
+  removes the per-release judgement call about "is this breaking?"
+
+### Negative
+
+- The CHANGELOG requires discipline per PR. A PR that silently
+  changes public behaviour without touching CHANGELOG is a release
+  hazard. Code review has to catch this.
+- Pre-release tagging doubles the release types; only one of them
+  publishes to the real index. A human mistake (wrong tag shape)
+  uploads to the wrong place.
+
+### Neutral
+
+- We stay on `0.x`. A deliberate `1.0` release is its own ADR when
+  the API surface stabilises.
+
+## Alternatives considered
+
+### Option A — Continue untracked, cut versions by feel
+
+- **Pro:** Zero policy overhead.
+- **Con:** Consumers cannot plan. "Is this bump safe?" has no
+  answer.
+- **Why rejected:** We just spent an ADR (ADR-0020) removing the
+  damage caused by the opposite pattern.
+
+### Option B — Calendar versioning (e.g. `2026.4.0`)
+
+- **Pro:** Release dates are self-documenting.
+- **Con:** Does not convey breaking vs non-breaking. Consumers
+  have to read every CHANGELOG.
+- **Why rejected:** Semver's information density is the whole
+  point.
+
+### Option C — Bump version in `setup.py` on every PR
+
+- **Pro:** No env var plumbing.
+- **Con:** Every PR becomes a version-bump fight; commits cannot
+  be safely cherry-picked.
+- **Why rejected:** Tag-based is cleaner.
+
+## Follow-ups
+
+- Cut `v0.7.0` once the dust from the ADR-0017 through ADR-0023
+  chain settles. The CHANGELOG Unreleased section already describes
+  everything that belongs in it.
+- Document the PyPI token rotation schedule (separate security
+  ADR).
+- Verify the existing `python-upload-package.yml` workflow reads
+  the tag correctly. If it does not, fix it as part of the next
+  release.
+
+## References
+
+- [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+- [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+- [`.github/workflows/python-upload-package.yml`](../../../.github/workflows/python-upload-package.yml)
+- [`.github/workflows/python-upload-test-package.yml`](../../../.github/workflows/python-upload-test-package.yml)
+- [`setup.py`](../../../setup.py) — `PYPI_PACKAGE_VERSION` env var.

--- a/docs/governance/adr/0025-dependabot-auto-merge-policy.md
+++ b/docs/governance/adr/0025-dependabot-auto-merge-policy.md
@@ -1,0 +1,170 @@
+# ADR-0025: Dependabot auto-merge policy
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Deciders:** pdip maintainers
+- **Tags:** dependencies, ci, automation
+
+## Context
+
+Dependabot has been the primary source of dependency pressure in
+this repository. The ADR chain from 0017 onward produced a backlog
+of Dependabot PRs we triaged manually. Some are trivially safe
+(a patch bump of `coverage` to pick up a bug fix); some need
+careful review (a major bump of `Flask-Cors` or a driver swap).
+
+Handling them all by hand is wasteful. Handling them all by
+auto-merge is dangerous. We want a policy that treats the two
+cases differently.
+
+[ADR-0017](./0017-python-support-policy.md) already established
+that **a dependency upgrade that narrows the supported Python
+matrix is not auto-mergeable.** This ADR extends that with a rule
+set for everything else.
+
+## Decision
+
+### 1. What auto-merges
+
+A Dependabot PR auto-merges when **all** of the following are true:
+
+1. It is a **patch-level bump** (third component of semver) of a
+   library that is already pinned in `requirements.txt` or
+   `setup.py`.
+2. Every job on the CI matrix is green (including 3.9–3.14 ×
+   Linux / macOS / Windows, coverage floor, CodeQL, Analyze).
+3. The PR's changed files are **only** dependency manifests
+   (`requirements.txt`, `setup.py`). No source or test edits.
+4. The bump does **not** drop a Python version in pdip's
+   supported window (ADR-0017 / ADR-0020).
+
+Qualifying patch bumps are merged with the `merge` method and the
+default merge commit message.
+
+### 2. What waits for human review
+
+A Dependabot PR is reviewed by a maintainer before merge when:
+
+- The bump is **minor** or **major** (second or first component of
+  semver). Even if CI is green, the release notes get a human read
+  before it lands — breakage often hides in behaviour, not tests.
+- The changed files extend beyond the two dependency manifests.
+- The PR's CI has any red matrix cell.
+- The bump touches a driver listed in the **integrator** extra
+  (`oracledb`, `confluent-kafka`, `psycopg2-binary`,
+  `mysql-connector-python`, `pyodbc`). These sit behind unit test
+  stubs (ADR-0021, ADR-0022) but the real behaviour only shows up
+  in integration tests, which CI does not run.
+
+### 3. What is declined
+
+A Dependabot PR is **closed without merging** when:
+
+- The bump requires raising `python_requires` and no companion
+  ADR raises the floor (ADR-0017). The PR is closed with a link
+  to ADR-0017 so the policy is visible to the bot (and to
+  anyone who opens the PR later).
+
+### 4. Grouping
+
+`dependabot.yml` groups patch-level bumps across the `pip`
+ecosystem into one PR per week. Grouped PRs still auto-merge
+when every package in the group satisfies rule 1. If any one
+package would flag rule 1, the whole group waits for review.
+
+### 5. Implementation
+
+- `.github/dependabot.yml` enables grouped PRs.
+- `.github/workflows/dependabot-auto-merge.yml` (to be added in a
+  follow-up PR) uses the `dependabot/fetch-metadata` action to
+  read the semver jump, and `gh pr merge --auto --merge` for
+  qualifying PRs.
+- Until the auto-merge workflow is wired up, maintainers apply
+  this policy manually on each Dependabot PR. The decision table
+  in this ADR is the script they follow.
+
+### 6. Breaking-change sentinels
+
+These keywords in a Dependabot PR title or release-notes block
+always bump the PR out of auto-merge, regardless of semver:
+
+- `drop support for Python`
+- `remove` (followed by a public-API symbol)
+- `breaking change`
+- `CVE` (so a security bump gets explicit attention even if it's
+  a patch)
+
+## Consequences
+
+### Positive
+
+- Routine maintenance lands in minutes, not days. Security patch
+  bumps (e.g. the recent `cryptography` 43 → 46 grouped with
+  Flask / Werkzeug) don't sit around waiting for a human to look.
+- Risky bumps still get a human. A driver swap has to pass the
+  integrator-extras rule *and* be read.
+- Policy is codified in one place; a new maintainer does not have
+  to reason about each PR from first principles.
+
+### Negative
+
+- Auto-merge means a bad Dependabot PR that passes CI lands
+  without human eyes. The existing unit-test suite (ADR-0018)
+  plus the coverage floor (ADR-0023) are our only backstop. We
+  accept this for patch-level bumps of already-pinned packages.
+- The "breaking-change sentinel" list is a best-effort filter. A
+  PR with careful release notes that avoid those phrases slips
+  through.
+
+### Neutral
+
+- The policy does not govern **security advisories** reported by
+  Dependabot Security Updates (not the version PRs). Those are
+  triaged on the security dashboard; they get their own ADR when
+  a concrete case calls for one.
+
+## Alternatives considered
+
+### Option A — Auto-merge every green Dependabot PR
+
+- **Pro:** Simplest rule.
+- **Con:** A minor or major bump with subtle behaviour changes
+  lands unexamined. A few hours of human attention prevents a
+  full release cycle of regressions.
+- **Why rejected:** Too permissive.
+
+### Option B — Human review for every Dependabot PR
+
+- **Pro:** Nothing unreviewed reaches main.
+- **Con:** Patch-level bumps are effectively always safe when CI
+  is green. Requiring human review burns attention with no real
+  risk reduction.
+- **Why rejected:** Opportunity cost is real; attention is a
+  budget, not a freebie.
+
+### Option C — Only auto-merge dev-only dependencies
+
+- **Pro:** Runtime deps always get a human.
+- **Con:** The most common patch bumps (Flask, Werkzeug,
+  cryptography) are runtime deps; excluding them means no
+  auto-merge in practice.
+- **Why rejected:** Most of the value is in runtime patch
+  bumps.
+
+## Follow-ups
+
+- Add `.github/dependabot.yml` with group and schedule.
+- Add `.github/workflows/dependabot-auto-merge.yml` that
+  implements the rules above.
+- Revisit this ADR once the auto-merge workflow has one release
+  cycle of data — in particular, whether the
+  integrator-extras exclusion is too broad.
+
+## References
+
+- [ADR-0017](./0017-python-support-policy.md) — Python support
+  matrix is owned by `python_requires`.
+- [ADR-0018](./0018-testing-strategy.md) — Testing pyramid and CI
+  gating.
+- [ADR-0023](./0023-coverage-floor-policy.md) — Coverage floor.
+- [Dependabot fetch-metadata action](https://github.com/dependabot/fetch-metadata).

--- a/docs/governance/adr/README.md
+++ b/docs/governance/adr/README.md
@@ -31,6 +31,8 @@ shapes how the framework is built and used. See the parent
 | [0021](./0021-cx-oracle-to-python-oracledb.md) | Migrate the Oracle adapter from `cx_Oracle` to `python-oracledb` | Accepted | dependencies, oracle, integrator |
 | [0022](./0022-kafka-python-replacement.md) | Replace `kafka-python` with `confluent-kafka` for the Kafka adapter | Accepted | dependencies, kafka, integrator |
 | [0023](./0023-coverage-floor-policy.md) | Coverage floor policy | Accepted | testing, ci, quality |
+| [0024](./0024-release-process.md) | Release process — semver, CHANGELOG, and PyPI publish | Accepted | release, packaging, process |
+| [0025](./0025-dependabot-auto-merge-policy.md) | Dependabot auto-merge policy | Accepted | dependencies, ci, automation |
 
 ## Status legend
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,3 +75,5 @@ nav:
           - ADR-0021 cx_Oracle to python-oracledb: governance/adr/0021-cx-oracle-to-python-oracledb.md
           - ADR-0022 kafka-python replacement: governance/adr/0022-kafka-python-replacement.md
           - ADR-0023 Coverage floor policy: governance/adr/0023-coverage-floor-policy.md
+          - ADR-0024 Release process: governance/adr/0024-release-process.md
+          - ADR-0025 Dependabot auto-merge policy: governance/adr/0025-dependabot-auto-merge-policy.md


### PR DESCRIPTION
## Summary

Closes three follow-ups from the Python 3.14 readiness chain:

- **Coverage ratchet** (ADR-0023) — floor moves `20 → 30` to match the new measured coverage after ADR-0021 / ADR-0022 / MySQL-bump test additions.
- **mkdocs deploy workflow** — `docs-deploy.yml` builds the mkdocs-material site on every PR and publishes to GitHub Pages on push to `main`.
- **Two new governance ADRs**:
  - **ADR-0024** — Release process: maps `CHANGELOG` sections to semver parts, declares tag-based PyPI publish, documents pre-release and yank rules.
  - **ADR-0025** — Dependabot auto-merge policy: patch-level bumps of already-pinned packages with green CI auto-merge; minor / major / integrator-extra bumps still require human review; bumps that narrow the Python matrix are declined per ADR-0017.

## Changes

### Coverage
- `.coveragerc` — `fail_under 20 → 30`.
- `.github/workflows/package-build-and-tests.yml` — `--fail-under=30`.

### Docs pipeline
- `.github/workflows/docs-deploy.yml` (new) — strict mode deliberately off because ADRs cross-link to repo files (setup.py, workflow yml, .coveragerc) that are not part of the docs tree; warnings still surface in the build log and readers on GitHub see the linked files directly.
- Needs GitHub Pages **Source = GitHub Actions** in the repo settings for the deploy step to succeed. Until that's configured, the build step still runs on every PR.

### Governance
- `docs/governance/adr/0024-release-process.md` — new.
- `docs/governance/adr/0025-dependabot-auto-merge-policy.md` — new.
- `docs/governance/adr/README.md` — index updated.
- `mkdocs.yml` — nav entries added.
- `CHANGELOG.md` — Added / Changed entries cover the three changes and clarify the ADR count (23 → 25).

## Verified

- **Python 3.11** (local venv): 86/86 green, coverage report prints 30 %, `--fail-under=30` passes.
- **Python 3.14** (uv 3.14.0rc2): 86/86 green.
- `mkdocs build` produces a site in `/tmp/pdip-site` with 5 top-level entries (index, contributing, governance, assets, 404).

## Non-goals

- **flake8 tightening** deliberately left out; 388 warnings total (205 unused imports, 50 empty f-strings, plus smaller categories). A focused PR that fixes the 5 real bug markers (`E711` / `E712` / `E722`) and adds them to the hard-fail set is a better shape for that work.
- **Enabling GitHub Pages** requires repo-settings access; the workflow is correct but the deploy step is gated on the setting. Once Pages is on, the next push to `main` publishes.

## Follow-ups (not in this PR)

- Cut `v0.7.0` per ADR-0024 (the Unreleased CHANGELOG section already describes the full 0.6.10 → 0.7.0 delta).
- Implement ADR-0025's auto-merge workflow (`.github/dependabot.yml` group config + `dependabot-auto-merge.yml`).
- Flake8 tightening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_