### PR TITLE
chore: gitignore .claude/ worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ node_modules
 _trial*
 .vscode/settings.json
 **/temp/
+
+# Claude Code agent worktrees (local, per-session)
+.claude/


### PR DESCRIPTION
## Summary

Add `.claude/` to `.gitignore`. Claude Code agents launched with `isolation: worktree` create session-local checkouts under `.claude/worktrees/<id>/`. Those worktrees are per-session artifacts and never belong in the repo; the existing `stop-hook-git-check.sh` surfaced the gap when this session dispatched four parallel agents.

Pure hygiene, no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_