### PR TITLE
chore(release): cut v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ for the public API surface described in
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-04-24
+
 ### Added
 
 - Governance methodology under `docs/governance/` with 23 Architecture
@@ -202,5 +204,6 @@ Earlier history is preserved in the git log; see
 `git log --oneline` and the tags on the `ahmetcagriakca/pdip`
 repository.
 
-[Unreleased]: https://github.com/ahmetcagriakca/pdip/compare/v0.6.10...HEAD
+[Unreleased]: https://github.com/ahmetcagriakca/pdip/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/ahmetcagriakca/pdip/releases/tag/v0.7.0
 [0.6.10]: https://github.com/ahmetcagriakca/pdip/releases/tag/v0.6.10

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 here = Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
-env_version = getenv('PYPI_PACKAGE_VERSION', default='0.6.10')
+env_version = getenv('PYPI_PACKAGE_VERSION', default='0.7.0')
 version = env_version.replace('v', '')
 setup(
     name='pdip',


### PR DESCRIPTION
## Summary

Cut **pdip v0.7.0** per the release process established in [ADR-0024](../docs/governance/adr/0024-release-process.md). This PR **does not tag** — tagging (`git tag -s v0.7.0 && git push --tags`) happens after merge and triggers the PyPI publish workflow.

## Changes

- `CHANGELOG.md`:
  - Rename existing `## [Unreleased]` → `## [0.7.0] — 2026-04-24`.
  - New empty `## [Unreleased]` heading at the top of the entry list.
  - Link references at the bottom updated: `[Unreleased]: ...compare/v0.7.0...HEAD` and new `[0.7.0]: ...releases/tag/v0.7.0`.
- `setup.py`: `env_version` default bumped from `0.6.10` to `0.7.0`, so tagless local builds produce `pdip-0.7.0`.

## Release content (0.6.10 → 0.7.0)

A modernization release. Highlights:

- **Oracle adapter** moves from `cx_Oracle` to `python-oracledb` in thin mode (ADR-0021). No more Oracle Instant Client requirement.
- **Kafka adapter** moves from the unmaintained `kafka-python` to `confluent-kafka` with a compatibility translation layer for caller config (ADR-0022).
- **Python floor raised** from 3.8 to 3.9 (ADR-0020 — breaking for 3.8 consumers). Unblocks `mysql-connector-python>=9.1,<10`.
- **CI matrix** expanded to 3.9 / 3.10 / 3.11 / 3.12 / 3.13 / 3.14 × Ubuntu / macOS / Windows (ADR-0019), with real 3.14 compatibility fixes: `multiprocessing` spawn pin, relative-import fix in `ModuleFinder`, class-level `__annotations__` lookups.
- **Coverage floor** of 30 % enforced in CI via `.coveragerc` (ADR-0023).
- **Governance** grows by 9 ADRs (0017–0025): Python support policy, testing strategy, 3.14 adoption plan, floor raise, two driver migrations, coverage floor, release process, Dependabot auto-merge policy.
- `run_tests.py` honours exit codes now, and `TestCase` discovery finds every class per file (previously silent bugs). Suite goes from 24 reported runs to **86 green**.
- Two real bug fixes: `Repository.delete_by_id` / `delete` now branch on dialect for UUID binding; `test_process_error` no longer indexes `results[0]` statically.
- `requirements.txt` slimmed: `pandas`, `kafka-python`, `func-timeout` moved into the `integrator` extra (their rightful place per ADR-0014).

## Test plan

- [ ] CI green on the full 3.9–3.14 × 3-OS matrix.
- [ ] After merge, tag `v0.7.0` and confirm `python-upload-package.yml` publishes to PyPI.
- [ ] Spot-check the rendered CHANGELOG entry at <https://github.com/ahmetcagriakca/pdip/releases/tag/v0.7.0> after the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_