### PR TITLE
ADR-0025 implementation: Dependabot auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot configuration for pdip.
+#
+# Policy source: docs/governance/adr/0025-dependabot-auto-merge-policy.md
+# (ADR-0025 — Dependabot auto-merge policy).
+#
+# Grouping rationale:
+#   - Runtime / dev libraries pinned in requirements.txt and setup.py are
+#     grouped into a single weekly PR (`pip-runtime`). Patch-level grouped
+#     PRs auto-merge via .github/workflows/dependabot-auto-merge.yml.
+#   - Integrator-extra drivers (oracledb, confluent-kafka, psycopg2-binary,
+#     mysql-connector-python, pyodbc, pandas) are NOT grouped. ADR-0025
+#     rule 2 blocks them from auto-merge regardless, and keeping them in
+#     their own PRs keeps the human-review queue focused.
 
 version: 2
 updates:
@@ -9,3 +18,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      pip-runtime:
+        patterns:
+          - "Flask"
+          - "Flask-*"
+          - "Flask_*"
+          - "flask-*"
+          - "Werkzeug"
+          - "cryptography"
+          - "PyYAML"
+          - "SQLAlchemy"
+          - "injector"
+          - "coverage"
+          - "dataclasses-json"
+          - "func-timeout"
+        exclude-patterns:
+          - "oracledb"
+          - "confluent-kafka"
+          - "psycopg2-binary"
+          - "mysql-connector-python"
+          - "pyodbc"
+          - "pandas"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,52 @@
+# Dependabot auto-merge workflow.
+#
+# Policy source: docs/governance/adr/0025-dependabot-auto-merge-policy.md
+# (ADR-0025 — Dependabot auto-merge policy).
+#
+# This workflow enables `gh pr merge --auto --merge` only for Dependabot PRs
+# that are patch-level semver bumps AND do not touch any integrator-extra
+# driver (ADR-0025 rule 2). Every other Dependabot PR is left for a
+# maintainer to review by hand.
+
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge qualifying Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-merge patch bumps that do not touch integrator extras
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+          # ADR-0025 rule 2: integrator-extra drivers and packages whose
+          # behaviour only shows up in integration tests never auto-merge.
+          integrator_extras="oracledb confluent-kafka psycopg2-binary mysql-connector-python pyodbc pandas func-timeout dataclasses-json"
+          # dependency-names is a comma-separated list.
+          normalized_names="$(echo "$DEPENDENCY_NAMES" | tr ',' '\n' | tr -d '[:space:]')"
+          for pkg in $integrator_extras; do
+            if echo "$normalized_names" | grep -Fxq "$pkg"; then
+              echo "Dependency '$pkg' is an integrator extra (ADR-0025 rule 2); skipping auto-merge."
+              exit 0
+            fi
+          done
+          echo "All updated dependencies are eligible for auto-merge: $DEPENDENCY_NAMES"
+          gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Summary

Implements [ADR-0025](../docs/governance/adr/0025-dependabot-auto-merge-policy.md) — the Dependabot auto-merge policy. Patch-level bumps of already-pinned packages with green CI merge themselves; minor / major / integrator-extra bumps still go through human review.

## Changes

- **`.github/dependabot.yml`** — extended: weekly `pip` updates, a `pip-runtime` group pattern that batches non-integrator-extra packages, `chore(deps)` commit-message prefix. Integrator-extra drivers (`oracledb`, `confluent-kafka`, `psycopg2-binary`, `mysql-connector-python`, `pyodbc`, `pandas`) are **excluded from the group** so they open their own PRs — they do not qualify for auto-merge anyway per ADR-0025 rule 2.
- **`.github/workflows/dependabot-auto-merge.yml`** (new):
  - Trigger: `on: pull_request_target` with `permissions: contents: write, pull-requests: write`.
  - Job guard: `if: github.actor == 'dependabot[bot]'`.
  - Step 1: `actions/checkout@v4`.
  - Step 2: `dependabot/fetch-metadata@v2` — exposes `update-type` and `dependency-names`.
  - Step 3: conditional on `steps.metadata.outputs.update-type == 'version-update:semver-patch'`. A bash guard scans the comma-separated `dependency-names` and exits 0 without merging if any match the integrator-extras list (`oracledb`, `confluent-kafka`, `psycopg2-binary`, `mysql-connector-python`, `pyodbc`, `pandas`, `func-timeout`, `dataclasses-json`).
  - When all three guards pass: `gh pr merge --auto --merge "$PR_URL"` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
- Both YAML files parse clean (`yaml.safe_load`).

## What this means for routine bumps

- `cryptography` / `Flask` / `Werkzeug` patch bump from Dependabot → CI runs, auto-merges on green. No human needed.
- Any bump of an integrator-extra driver → stays open for human review.
- Any minor or major bump of anything → stays open for human review.
- A bump that narrows the Python matrix → already blocked by ADR-0017 before Dependabot even opens it.

## Verified

- Existing test suite: `python run_tests.py` — 86/86 green.
- `yaml.safe_load` passes on both new files.

## Follow-ups (not in this PR)

- Monitor the first real auto-merge event and make sure the workflow correctness matches ADR-0025. If the integrator-extras exclusion turns out too broad or too narrow in practice, revisit ADR-0025 rule 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_