### PR TITLE
flake8: hard-fail E711/E712/E722 and fix 28 real-bug violations

### DIFF
--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with unittest and coverage

--- a/pdip/api/base/endpoint_base.py
+++ b/pdip/api/base/endpoint_base.py
@@ -62,7 +62,7 @@ class Endpoint:
 
     def find_input_type(self):
         input_types, input_names = self.input_types()
-        if input_types == None or len(input_types) == 0:
+        if input_types is None or len(input_types) == 0:
             return None, None
         elif len(input_types) == 1:
             return input_types[0], input_names[0]

--- a/pdip/api/base/endpoint_wrapper.py
+++ b/pdip/api/base/endpoint_wrapper.py
@@ -131,7 +131,7 @@ class EndpointWrapper:
     def create_parser(self, name, input_type: typing.Type[T]) -> RequestParser:
         parser: RequestParser = self.api.parser()
 
-        if TypeChecker().is_class(input_type) == True:
+        if TypeChecker().is_class(input_type):
             parser.add_argument(self.create_argument(name=name, type=input_type, location='form', help=name))
         else:
             parser.add_argument(self.create_argument(name=name, type=input_type, location='args', help=name))
@@ -144,7 +144,7 @@ class EndpointWrapper:
 
     def create_argument(self, name, type, location, help) -> Argument:
         specified_type = type
-        if TypeChecker().is_generic(type) == True:
+        if TypeChecker().is_generic(type):
             specified_type = type.__args__[0]
 
         if specified_type == bool:

--- a/pdip/dependency/container/dependency_container.py
+++ b/pdip/dependency/container/dependency_container.py
@@ -15,7 +15,7 @@ class DependencyContainer:
                                            configurations=configurations,
                                            excluded_modules=excluded_modules)
             cls.Instance.initialize_injection(initialize_flask=initialize_flask)
-        except:
+        except Exception:
             cls.cleanup()
             raise
 

--- a/pdip/utils/module_finder.py
+++ b/pdip/utils/module_finder.py
@@ -124,7 +124,7 @@ class ModuleFinder:
                         except Exception as ex:
                             raise
 
-        except:
+        except Exception:
             self.cleanup()
             raise
 

--- a/tests/integrationtests/integrator/integration/sql/mssql/test_integrator.py
+++ b/tests/integrationtests/integrator/integration/sql/mssql/test_integrator.py
@@ -42,7 +42,7 @@ class TestMssqlIntegration(TestCase):
                 ConnectionColumnBase(Name='NAME', Type='varchar(100)'),
             ]
 
-        except:
+        except Exception:
             self.tearDown()
             raise
 
@@ -91,7 +91,7 @@ class TestMssqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_single_process(self):
@@ -133,7 +133,7 @@ class TestMssqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_parallel(self):
@@ -175,5 +175,5 @@ class TestMssqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass

--- a/tests/integrationtests/integrator/integration/sql/mysql/test_integrator.py
+++ b/tests/integrationtests/integrator/integration/sql/mysql/test_integrator.py
@@ -43,7 +43,7 @@ class TestMysqlIntegration(TestCase):
                 ConnectionColumnBase(Name='NAME', Type='varchar(100)'),
             ]
 
-        except:
+        except Exception:
             self.tearDown()
             raise
 
@@ -92,7 +92,7 @@ class TestMysqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_single_process(self):
@@ -134,7 +134,7 @@ class TestMysqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_parallel(self):
@@ -176,5 +176,5 @@ class TestMysqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass

--- a/tests/integrationtests/integrator/integration/sql/oracle/test_integrator.py
+++ b/tests/integrationtests/integrator/integration/sql/oracle/test_integrator.py
@@ -43,7 +43,7 @@ class TestOracleIntegration(TestCase):
                 ConnectionColumnBase(Name='NAME', Type='varchar(100)'),
             ]
 
-        except:
+        except Exception:
             self.tearDown()
             raise
 
@@ -92,7 +92,7 @@ class TestOracleIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_single_process(self):
@@ -134,7 +134,7 @@ class TestOracleIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_parallel(self):
@@ -176,5 +176,5 @@ class TestOracleIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass

--- a/tests/integrationtests/integrator/integration/sql/postgresql/test_integrator.py
+++ b/tests/integrationtests/integrator/integration/sql/postgresql/test_integrator.py
@@ -43,7 +43,7 @@ class TestPostgresqlIntegration(TestCase):
                 ConnectionColumnBase(Name='NAME', Type='varchar(100)'),
             ]
 
-        except:
+        except Exception:
             self.tearDown()
             raise
 
@@ -92,7 +92,7 @@ class TestPostgresqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_single_process(self):
@@ -134,7 +134,7 @@ class TestPostgresqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass
 
     def test_integration_parallel(self):
@@ -176,5 +176,5 @@ class TestPostgresqlIntegration(TestCase):
                     .drop_table(schema=self.source_schema,
                                 table=self.source_table
                                 )
-            except:
+            except Exception:
                 pass

--- a/tests/unittests/api/basic_app_with_cqrs/test_basic_app_with_cqrs.py
+++ b/tests/unittests/api/basic_app_with_cqrs/test_basic_app_with_cqrs.py
@@ -14,7 +14,7 @@ class TestBasicAppWithCqrs(TestCase):
             engine = self.pdi.get(DatabaseSessionManager).engine
             Base.metadata.create_all(engine)
             self.client = self.pdi.get(FlaskAppWrapper).test_client()
-        except:
+        except Exception:
             self.tearDown()
             raise
 
@@ -34,7 +34,7 @@ class TestBasicAppWithCqrs(TestCase):
         assert response.status_code == 200
         response_data = response.get_data(as_text=True)
         json_data = json.loads(response_data)
-        assert json_data['IsSuccess'] == True
+        assert json_data['IsSuccess']
 
     def get_user(self, name):
         response = self.client.get(
@@ -43,7 +43,7 @@ class TestBasicAppWithCqrs(TestCase):
         assert response.status_code == 200
         response_data = response.get_data(as_text=True)
         json_data = json.loads(response_data)
-        assert json_data['IsSuccess'] == True
+        assert json_data['IsSuccess']
         return json_data['Result']['Data']
 
     def test_create_user(self):

--- a/tests/unittests/api/basic_app_with_error/test_basic_app_with_error.py
+++ b/tests/unittests/api/basic_app_with_error/test_basic_app_with_error.py
@@ -10,7 +10,7 @@ class TestBasicAppWithError(TestCase):
         try:
             self.pdi = Pdi()
             self.client = self.pdi.get(FlaskAppWrapper).test_client()
-        except:
+        except Exception:
             self.tearDown()
             raise
 

--- a/tests/unittests/api/basic_app_with_log/test_basic_app_with_log.py
+++ b/tests/unittests/api/basic_app_with_log/test_basic_app_with_log.py
@@ -18,7 +18,7 @@ class TestBasicAppWithLog(TestCase):
             engine = self.pdi.get(DatabaseSessionManager).engine
             Base.metadata.create_all(engine)
             self.client = self.pdi.get(FlaskAppWrapper).test_client()
-        except:
+        except Exception:
             self.tearDown()
             raise
 

--- a/tests/unittests/configuration/test_ConfigManager.py
+++ b/tests/unittests/configuration/test_ConfigManager.py
@@ -13,7 +13,7 @@ class TestConfigManager(TestCase):
                 os.path.dirname(os.path.abspath(__file__))))
             self.module_finder = ModuleFinder(root_directory=self.root_directory)
             self.config_manager = None
-        except:
+        except Exception:
             self.tearDown()
             raise
 

--- a/tests/unittests/cryptography/test_cryptography_service.py
+++ b/tests/unittests/cryptography/test_cryptography_service.py
@@ -11,7 +11,7 @@ class TestCryptographyService(TestCase):
     def setUp(self):
         try:
             self.pdi = Pdi(configurations=[self.generate_key])
-        except:
+        except Exception:
             self.tearDown()
             raise
 


### PR DESCRIPTION
## Summary

Fix 28 real-bug-marker flake8 violations and extend the CI hard-fail select to include them going forward. Flake8 will now reject new `E711` / `E712` / `E722` regressions in addition to the existing `E9` / `F63` / `F7` / `F82`.

## Scope — real bugs only

The actual count was higher than the triage estimate (28, not 5). All three codes are bug markers, not style:

- **E711** — `== None` / `!= None` (1 site)
- **E712** — `== True` / `== False` (4 sites)
- **E722** — bare `except:` (23 sites)

The repo still has ~360 other flake8 warnings (F401 unused imports, F541 empty f-strings, etc.) — those are **intentionally out of scope**; they are style issues, not bugs, and belong in their own PR.

## Changes

### Source fixes

**E711 (1):**
- `pdip/api/base/endpoint_base.py:65` — `if input_types == None or len(input_types) == 0:` → `if input_types is None or len(input_types) == 0:`

**E712 (4):**
- `pdip/api/base/endpoint_wrapper.py:134` — `if TypeChecker().is_class(input_type) == True:` → `if TypeChecker().is_class(input_type):`
- `pdip/api/base/endpoint_wrapper.py:147` — `if TypeChecker().is_generic(type) == True:` → `if TypeChecker().is_generic(type):`
- `tests/unittests/api/basic_app_with_cqrs/test_basic_app_with_cqrs.py` lines 37 and 46 — `assert json_data['IsSuccess'] == True` → `assert json_data['IsSuccess']`

**E722 (23):** All bare `except:` → `except Exception:`:
- `pdip/dependency/container/dependency_container.py:18`
- `pdip/utils/module_finder.py:127`
- 16 sites across `tests/integrationtests/integrator/integration/sql/{mssql,mysql,oracle,postgresql}/test_integrator.py`
- 5 sites across `tests/unittests/api/*`, `tests/unittests/configuration/`, `tests/unittests/cryptography/`

Behaviour is preserved: `except Exception:` catches everything bare `except:` was actually catching except `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — which are the three things you should not swallow anyway.

### CI

`.github/workflows/package-build-and-tests.yml` — the hard-fail flake8 select is extended:

```diff
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics
```

The `--exit-zero` soft-pass line is untouched.

## Verified

- `flake8 pdip/ tests/ --select E711,E712,E722 --max-line-length=127` → zero output.
- `flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics` → zero count.
- `python run_tests.py` → 86/86 green.

## Follow-ups (not in this PR)

- Flake8 F401 (unused imports) cleanup — ~205 occurrences, separate PR.
- Flake8 F541 (empty f-strings) — ~50 occurrences, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_