### PR TITLE
fix(pubsub): unsubscribe precedence + ChannelQueue.get_nowait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ for the public API surface described in
 
 ## [Unreleased]
 
+### Added
+
+- `pdip.integrator.pubsub.base.ChannelQueue.get_nowait()` — non-blocking
+  accessor that mirrors ``queue.Queue.get_nowait``. Lets observers and
+  tests drain a channel without blocking the caller. The existing
+  `get()` still blocks, preserving the production broker loop.
+
+### Fixed
+
+- `pdip.integrator.pubsub.base.MessageBroker.unsubscribe` had an
+  operator-precedence bug: `event is not None or event != "" and event
+  in self.subscribers.keys()`. Because `and` binds tighter than `or`,
+  the first clause short-circuited the guard to truthy for any
+  non-None event, even ones that were never subscribed — so the
+  "Cant unsubscribe" warning path was dead code and the mutation
+  branch always ran. Replaced with the intended
+  `if event and event in self.subscribers:` and backed by new unit
+  tests (9 cases in
+  `tests/unittests/integrator/pubsub/test_message_broker.py`).
+
 ## [0.7.0] — 2026-04-24
 
 ### Added

--- a/pdip/integrator/pubsub/base/channel_queue.py
+++ b/pdip/integrator/pubsub/base/channel_queue.py
@@ -11,5 +11,12 @@ class ChannelQueue:
     def get(self):
         return self.channel_queue.get()
 
+    def get_nowait(self):
+        """Return a message without blocking; raise ``queue.Empty`` if
+        the channel has no pending messages. Mirrors
+        ``queue.Queue.get_nowait`` so callers can drain a channel in
+        tests or observability paths without blocking the caller."""
+        return self.channel_queue.get_nowait()
+
     def done(self):
         return self.channel_queue.task_done()

--- a/pdip/integrator/pubsub/base/message_broker.py
+++ b/pdip/integrator/pubsub/base/message_broker.py
@@ -80,8 +80,12 @@ class MessageBroker:
             self.subscribers[event].append(callback)
 
     def unsubscribe(self, event, callback):
-        if event is not None or event != "" \
-                and event in self.subscribers.keys():
+        # Previously: ``if event is not None or event != "" and event
+        # in self.subscribers.keys():``. ``and`` binds tighter than
+        # ``or``, so the first clause short-circuited to True whenever
+        # ``event`` was any non-None value — including events that had
+        # never been subscribed. The ``else`` warning was dead code.
+        if event and event in self.subscribers:
             self.subscribers[event] = list(
                 filter(
                     lambda x: x is not callback,

--- a/tests/unittests/integrator/integration/test_integration_execution.py
+++ b/tests/unittests/integrator/integration/test_integration_execution.py
@@ -47,13 +47,14 @@ def _build_execution(adapter):
 
 
 def _drain(channel):
-    """Pull every message off ``channel`` by reaching through to the
-    underlying ``queue.Queue``. ``ChannelQueue.get`` forwards blindly to
-    the queue's blocking ``get`` — fine in production, hostile in a
-    test — so we access ``channel_queue`` directly and stop on empty."""
+    """Pull every message off ``channel`` non-blockingly via the
+    public ``ChannelQueue.get_nowait`` API."""
     events = []
-    while not channel.channel_queue.empty():
-        events.append(channel.channel_queue.get_nowait())
+    while True:
+        try:
+            events.append(channel.get_nowait())
+        except queue.Empty:
+            break
     return events
 
 

--- a/tests/unittests/integrator/operation/test_operation_execution.py
+++ b/tests/unittests/integrator/operation/test_operation_execution.py
@@ -30,11 +30,14 @@ from pdip.integrator.pubsub.base import ChannelQueue  # noqa: E402
 
 
 def _drain(channel):
-    """Pull every message off ``channel`` by reaching through to the
-    underlying ``queue.Queue``; ``ChannelQueue.get`` blocks forever."""
+    """Pull every message off ``channel`` non-blockingly via the
+    public ``ChannelQueue.get_nowait`` API."""
     events = []
-    while not channel.channel_queue.empty():
-        events.append(channel.channel_queue.get_nowait())
+    while True:
+        try:
+            events.append(channel.get_nowait())
+        except queue.Empty:
+            break
     return events
 
 

--- a/tests/unittests/integrator/pubsub/test_channel_queue.py
+++ b/tests/unittests/integrator/pubsub/test_channel_queue.py
@@ -39,6 +39,16 @@ class ChannelQueueRoundTripsMessages(TestCase):
         # single call below must succeed.
         self.channel.done()
 
+    def test_get_nowait_returns_message_when_available(self):
+        message = TaskMessage(event="nb")
+        self.channel.put(message)
+        self.assertIs(self.channel.get_nowait(), message)
+
+    def test_get_nowait_raises_queue_empty_when_no_message(self):
+        import queue as _q
+        with self.assertRaises(_q.Empty):
+            self.channel.get_nowait()
+
 
 class PublisherSendsMessagesThroughChannel(TestCase):
     def setUp(self):

--- a/tests/unittests/integrator/pubsub/test_message_broker.py
+++ b/tests/unittests/integrator/pubsub/test_message_broker.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``MessageBroker.subscribe`` / ``unsubscribe``.
+
+The broker owns a ``multiprocessing.Manager`` + worker + listener in
+production. Those are not exercised here — they belong to integration
+tests. These tests exercise the in-process subscriber bookkeeping,
+which a pre-existing operator-precedence bug in ``unsubscribe`` was
+silently corrupting.
+"""
+
+# Stub pandas + func_timeout — the broker module imports through the
+# integrator package tree which touches optional-extras adapters.
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.pubsub.base.message_broker import MessageBroker  # noqa: E402
+
+
+class MessageBrokerSubscriberBookkeeping(TestCase):
+    def setUp(self):
+        self.broker = MessageBroker(logger=MagicMock(name="logger"))
+
+    def test_subscribe_stores_callback_under_event(self):
+        cb = MagicMock()
+        self.broker.subscribe("EVT", cb)
+        self.assertEqual(self.broker.subscribers["EVT"], [cb])
+
+    def test_subscribe_appends_additional_callbacks(self):
+        cb1, cb2 = MagicMock(), MagicMock()
+        self.broker.subscribe("EVT", cb1)
+        self.broker.subscribe("EVT", cb2)
+        self.assertEqual(self.broker.subscribers["EVT"], [cb1, cb2])
+
+    def test_subscribe_rejects_non_callable(self):
+        with self.assertRaises(ValueError):
+            self.broker.subscribe("EVT", "not a callable")
+
+    def test_subscribe_rejects_empty_event(self):
+        with self.assertRaises(ValueError):
+            self.broker.subscribe("", MagicMock())
+        with self.assertRaises(ValueError):
+            self.broker.subscribe(None, MagicMock())
+
+    def test_unsubscribe_removes_the_callback_from_its_event(self):
+        cb1, cb2 = MagicMock(), MagicMock()
+        self.broker.subscribe("EVT", cb1)
+        self.broker.subscribe("EVT", cb2)
+
+        self.broker.unsubscribe("EVT", cb1)
+
+        self.assertEqual(self.broker.subscribers["EVT"], [cb2])
+
+    def test_unsubscribe_leaves_other_events_alone(self):
+        cb = MagicMock()
+        self.broker.subscribe("EVT-A", cb)
+        self.broker.subscribe("EVT-B", cb)
+
+        self.broker.unsubscribe("EVT-A", cb)
+
+        self.assertEqual(self.broker.subscribers["EVT-A"], [])
+        self.assertEqual(self.broker.subscribers["EVT-B"], [cb])
+
+    def test_unsubscribe_warns_when_event_was_never_subscribed(self):
+        # Previously this path was dead: the operator-precedence bug
+        # forced the happy branch even for events not in
+        # ``self.subscribers``. A clean run must now log a warning
+        # and must not mutate ``subscribers``.
+        self.broker.unsubscribe("UNKNOWN", MagicMock())
+
+        self.broker.logger.warning.assert_called_once()
+        self.assertNotIn("UNKNOWN", self.broker.subscribers)
+
+    def test_unsubscribe_warns_when_event_is_empty(self):
+        self.broker.unsubscribe("", MagicMock())
+        self.broker.logger.warning.assert_called_once()
+
+    def test_unsubscribe_warns_when_event_is_none(self):
+        self.broker.unsubscribe(None, MagicMock())
+        self.broker.logger.warning.assert_called_once()


### PR DESCRIPTION
## Summary

Close the last two known bugs in the pubsub layer before the v0.7.0 dust settles. Both were flagged during the integrator-core-tests work but left for their own focused PR.

## 1. `MessageBroker.unsubscribe` precedence bug

### Before

```python
if event is not None or event != "" \
        and event in self.subscribers.keys():
```

Python binds `and` tighter than `or`, so this read:

```python
(event is not None) or ((event != "") and (event in self.subscribers))
```

For any non-`None` event — including events that had **never been subscribed** — the first clause short-circuits to `True` and the mutation branch runs. The `else` with the "Cant unsubscribe" warning was dead code. In practice you could "unsubscribe" from an event that didn't exist and the broker would silently create an empty list in `self.subscribers[event]` via the `filter(...)` and assign, because the code reads `self.subscribers[event]` on a path where that key was guaranteed not to exist.

### After

```python
if event and event in self.subscribers:
```

Empty strings, `None`, and unknown events all fall to the warning path. Only genuinely-subscribed events are mutated.

## 2. `ChannelQueue.get_nowait()`

`ChannelQueue.get()` forwards to `queue.Queue.get()` which blocks forever on empty. Fine in production, hostile in tests — the earlier integrator-core-tests PR had to reach past `ChannelQueue` to `channel.channel_queue.get_nowait()` to drain channels for assertions. Added a real `get_nowait()` on `ChannelQueue` that mirrors the underlying queue's API.

## Changes

- `pdip/integrator/pubsub/base/message_broker.py` — unsubscribe guard fixed.
- `pdip/integrator/pubsub/base/channel_queue.py` — new `get_nowait()` method with docstring.
- `tests/unittests/integrator/pubsub/test_message_broker.py` (new, 9 tests) — subscribe happy path + rejection, unsubscribe across events, unknown-event warning, empty-event warning, None-event warning.
- `tests/unittests/integrator/pubsub/test_channel_queue.py` (+2 tests) — `get_nowait()` returns message when available, raises `queue.Empty` when drained.
- `tests/unittests/integrator/integration/test_integration_execution.py` and `.../operation/test_operation_execution.py` — `_drain` helpers now use the public `channel.get_nowait()` instead of reaching through to `channel.channel_queue`.
- `CHANGELOG.md` — new `Unreleased` entries above the `[0.7.0]` section.

## Verified

- **Python 3.11**: 112/112 green, coverage 47 %.
- **Python 3.14** (uv-installed): 112/112 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_