### PR TITLE
test: cover integrator factories + initializers (+42 tests, subtree 92%)

### DIFF
--- a/tests/unittests/integrator/connection/factories/test_connection_source_adapter_factory.py
+++ b/tests/unittests/integrator/connection/factories/test_connection_source_adapter_factory.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``ConnectionSourceAdapterFactory``.
+
+The source factory mirrors the target factory, minus the ``InMemory``
+branch. We assert each routing case, each ``isinstance`` failure, and
+the currently-broken ``File`` / ``Queue`` paths (attributes never
+populated by ``__init__`` — see module docstring on the target
+factory test for the real-bug note).
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.exceptions import (  # noqa: E402
+    IncompatibleAdapterException,
+    NotSupportedFeatureException,
+)
+from pdip.integrator.connection.base import ConnectionSourceAdapter  # noqa: E402
+from pdip.integrator.connection.domain.enums import ConnectionTypes  # noqa: E402
+from pdip.integrator.connection.factories.connection_source_adapter_factory import (  # noqa: E402
+    ConnectionSourceAdapterFactory,
+)
+
+
+def _build_factory(sql=None, big_data=None, web_service=None):
+    sql = sql if sql is not None else MagicMock(spec=ConnectionSourceAdapter)
+    big_data = (
+        big_data if big_data is not None else MagicMock(spec=ConnectionSourceAdapter)
+    )
+    web_service = (
+        web_service
+        if web_service is not None
+        else MagicMock(spec=ConnectionSourceAdapter)
+    )
+    return ConnectionSourceAdapterFactory(
+        sql_source_adapter=sql,
+        big_data_source_adapter=big_data,
+        web_service_source_adapter=web_service,
+    )
+
+
+class ConnectionSourceAdapterFactoryRoutesBySupportedType(TestCase):
+    def test_sql_type_returns_the_sql_adapter_instance(self):
+        sql_adapter = MagicMock(spec=ConnectionSourceAdapter, name="sql")
+        factory = _build_factory(sql=sql_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.Sql)
+
+        self.assertIs(result, sql_adapter)
+
+    def test_bigdata_type_returns_the_bigdata_adapter_instance(self):
+        big_data_adapter = MagicMock(spec=ConnectionSourceAdapter, name="bigdata")
+        factory = _build_factory(big_data=big_data_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.BigData)
+
+        self.assertIs(result, big_data_adapter)
+
+    def test_webservice_type_returns_the_webservice_adapter_instance(self):
+        web_service_adapter = MagicMock(
+            spec=ConnectionSourceAdapter, name="web_service"
+        )
+        factory = _build_factory(web_service=web_service_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.WebService)
+
+        self.assertIs(result, web_service_adapter)
+
+
+class ConnectionSourceAdapterFactoryRejectsIncompatibleSlot(TestCase):
+    def test_sql_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(sql=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.Sql)
+
+    def test_bigdata_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(big_data=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.BigData)
+
+    def test_webservice_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(web_service=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.WebService)
+
+
+class ConnectionSourceAdapterFactoryUnsupportedPaths(TestCase):
+    """See the target-factory test's equivalent class for context —
+    ``File`` / ``Queue`` reference attributes that ``__init__`` never
+    assigns, producing ``AttributeError`` today."""
+
+    def test_file_type_raises_attribute_error_today(self):
+        factory = _build_factory()
+
+        with self.assertRaises(AttributeError):
+            factory.get_adapter(ConnectionTypes.File)
+
+    def test_queue_type_raises_attribute_error_today(self):
+        factory = _build_factory()
+
+        with self.assertRaises(AttributeError):
+            factory.get_adapter(ConnectionTypes.Queue)
+
+
+class ConnectionSourceAdapterFactoryRejectsUnknownType(TestCase):
+    def test_unknown_enum_value_raises_not_supported(self):
+        factory = _build_factory()
+
+        class _Fake:
+            name = "Unknown"
+
+            def __eq__(self, other):
+                return False
+
+        with self.assertRaises(NotSupportedFeatureException):
+            factory.get_adapter(_Fake())

--- a/tests/unittests/integrator/connection/factories/test_connection_target_adapter_factory.py
+++ b/tests/unittests/integrator/connection/factories/test_connection_target_adapter_factory.py
@@ -1,0 +1,148 @@
+"""Unit tests for ``ConnectionTargetAdapterFactory``.
+
+The factory returns one of its injected adapters keyed on the
+``ConnectionTypes`` enum. It raises ``IncompatibleAdapterException``
+when the candidate adapter does not implement
+``ConnectionTargetAdapter``, and ``NotSupportedFeatureException`` when
+asked for a type it does not know how to route.
+
+These tests pin down:
+
+* each supported connection type routes to the matching adapter,
+* the ``isinstance`` guard raises ``IncompatibleAdapterException``
+  when a registered slot holds a non-adapter object,
+* unknown enum values raise ``NotSupportedFeatureException``,
+* the ``File`` / ``Queue`` / ``InMemory`` branches reference
+  attributes that the ``__init__`` never sets — they raise
+  ``AttributeError`` in the current implementation. We record that
+  as a **real bug** (see README note) but still assert the
+  observable behaviour.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.exceptions import (  # noqa: E402
+    IncompatibleAdapterException,
+    NotSupportedFeatureException,
+)
+from pdip.integrator.connection.base import ConnectionTargetAdapter  # noqa: E402
+from pdip.integrator.connection.domain.enums import ConnectionTypes  # noqa: E402
+from pdip.integrator.connection.factories.connection_target_adapter_factory import (  # noqa: E402
+    ConnectionTargetAdapterFactory,
+)
+
+
+def _build_factory(sql=None, big_data=None, web_service=None):
+    """Return a factory with adapter slots filled by mocks that pass
+    ``isinstance(..., ConnectionTargetAdapter)`` unless the caller
+    overrides them."""
+    sql = sql if sql is not None else MagicMock(spec=ConnectionTargetAdapter)
+    big_data = (
+        big_data if big_data is not None else MagicMock(spec=ConnectionTargetAdapter)
+    )
+    web_service = (
+        web_service
+        if web_service is not None
+        else MagicMock(spec=ConnectionTargetAdapter)
+    )
+    return ConnectionTargetAdapterFactory(
+        sql_target_adapter=sql,
+        big_data_target_adapter=big_data,
+        web_service_target_adapter=web_service,
+    )
+
+
+class ConnectionTargetAdapterFactoryRoutesBySupportedType(TestCase):
+    def test_sql_type_returns_the_sql_adapter_instance(self):
+        sql_adapter = MagicMock(spec=ConnectionTargetAdapter, name="sql")
+        factory = _build_factory(sql=sql_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.Sql)
+
+        self.assertIs(result, sql_adapter)
+
+    def test_bigdata_type_returns_the_bigdata_adapter_instance(self):
+        big_data_adapter = MagicMock(spec=ConnectionTargetAdapter, name="bigdata")
+        factory = _build_factory(big_data=big_data_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.BigData)
+
+        self.assertIs(result, big_data_adapter)
+
+    def test_webservice_type_returns_the_webservice_adapter_instance(self):
+        web_service_adapter = MagicMock(
+            spec=ConnectionTargetAdapter, name="web_service"
+        )
+        factory = _build_factory(web_service=web_service_adapter)
+
+        result = factory.get_adapter(ConnectionTypes.WebService)
+
+        self.assertIs(result, web_service_adapter)
+
+
+class ConnectionTargetAdapterFactoryRejectsIncompatibleSlot(TestCase):
+    def test_sql_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(sql=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.Sql)
+
+    def test_bigdata_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(big_data=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.BigData)
+
+    def test_webservice_slot_filled_with_non_adapter_raises_incompatible(self):
+        factory = _build_factory(web_service=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get_adapter(ConnectionTypes.WebService)
+
+
+class ConnectionTargetAdapterFactoryUnsupportedPaths(TestCase):
+    """``File`` / ``Queue`` / ``InMemory`` reference attributes that
+    ``__init__`` never assigns. Today they raise ``AttributeError``
+    rather than a friendlier ``NotSupportedFeatureException`` — see
+    the module docstring. We pin down the current behaviour so any
+    future fix (which should switch them to raise
+    ``NotSupportedFeatureException``) is a deliberate test update,
+    not a silent change."""
+
+    def test_file_type_raises_attribute_error_today(self):
+        factory = _build_factory()
+
+        with self.assertRaises(AttributeError):
+            factory.get_adapter(ConnectionTypes.File)
+
+    def test_queue_type_raises_attribute_error_today(self):
+        factory = _build_factory()
+
+        with self.assertRaises(AttributeError):
+            factory.get_adapter(ConnectionTypes.Queue)
+
+    def test_in_memory_type_raises_attribute_error_today(self):
+        factory = _build_factory()
+
+        with self.assertRaises(AttributeError):
+            factory.get_adapter(ConnectionTypes.InMemory)
+
+
+class ConnectionTargetAdapterFactoryRejectsUnknownType(TestCase):
+    def test_unknown_enum_value_raises_not_supported(self):
+        # Enum.__call__ accepts only registered values, so we use a
+        # stand-in object whose equality checks all miss the known
+        # branches — that exercises the final ``else`` clause.
+        factory = _build_factory()
+
+        class _Fake:
+            name = "Unknown"
+
+            def __eq__(self, other):
+                return False
+
+        with self.assertRaises(NotSupportedFeatureException):
+            factory.get_adapter(_Fake())

--- a/tests/unittests/integrator/event/test_integrator_event_manager_factory.py
+++ b/tests/unittests/integrator/event/test_integrator_event_manager_factory.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``IntegratorEventManagerFactory``.
+
+Same subclass-discovery pattern as the initializer factories:
+
+* return the default when it is the only registered subclass,
+* prefer a custom subclass when both are registered,
+* delegate resolution to the ``ServiceProvider``.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.event.base.default_integrator_event_manager import (  # noqa: E402
+    DefaultIntegratorEventManager,
+)
+from pdip.integrator.event.base.integrator_event_manager import (  # noqa: E402
+    IntegratorEventManager,
+)
+from pdip.integrator.event.base.integrator_event_manager_factory import (  # noqa: E402
+    IntegratorEventManagerFactory,
+)
+
+
+class IntegratorEventManagerFactoryChoosesSubclass(TestCase):
+    def test_returns_default_when_it_is_the_only_subclass(self):
+        provider = MagicMock(name="service_provider")
+        sentinel = MagicMock(name="default_event_manager")
+        provider.get.return_value = sentinel
+
+        factory = IntegratorEventManagerFactory(service_provider=provider)
+        result = factory.get()
+
+        self.assertIs(result, sentinel)
+        provider.get.assert_called_once()
+
+    def test_prefers_custom_subclass_over_default(self):
+        class _Custom(IntegratorEventManager):
+            def log(self, data, message, exception=None):
+                return None
+
+            def initialize(self, data):
+                return None
+
+            def start(self, data):
+                return None
+
+            def finish(self, data, exception=None):
+                return None
+
+            def integration_initialize(self, data, message):
+                return None
+
+            def integration_start(self, data, message):
+                return None
+
+            def integration_finish(self, data, data_count, message, exception=None):
+                return None
+
+            def integration_target_truncate(self, data, row_count):
+                return None
+
+            def integration_execute_source(self, data, row_count):
+                return None
+
+            def integration_execute_target(self, data, row_count):
+                return None
+
+        try:
+            provider = MagicMock(name="service_provider")
+            resolved = MagicMock(name="custom_event_manager")
+            provider.get.return_value = resolved
+
+            factory = IntegratorEventManagerFactory(service_provider=provider)
+            result = factory.get()
+
+            self.assertIs(result, resolved)
+            requested = provider.get.call_args[0][0]
+            self.assertIsNot(requested, DefaultIntegratorEventManager)
+            self.assertTrue(issubclass(requested, IntegratorEventManager))
+        finally:
+            del _Custom

--- a/tests/unittests/integrator/initializer/test_default_integrator_initializer.py
+++ b/tests/unittests/integrator/initializer/test_default_integrator_initializer.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``DefaultIntegratorInitializer``.
+
+The default initializer wires the message broker, subscribes the
+event manager to every lifecycle event, starts the broker, and
+delegates to the injected ``ExecutionInitializerFactory``. Each
+interaction is a contract with the broker, so we verify them by
+capturing subscriptions via a mock broker rather than spinning up a
+real one.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.domain.enums.events import (  # noqa: E402
+    EVENT_EXECUTION_FINISHED,
+    EVENT_EXECUTION_INITIALIZED,
+    EVENT_EXECUTION_INTEGRATION_EXECUTE_SOURCE,
+    EVENT_EXECUTION_INTEGRATION_EXECUTE_TARGET,
+    EVENT_EXECUTION_INTEGRATION_EXECUTE_TRUNCATE,
+    EVENT_EXECUTION_INTEGRATION_FINISHED,
+    EVENT_EXECUTION_INTEGRATION_INITIALIZED,
+    EVENT_EXECUTION_INTEGRATION_STARTED,
+    EVENT_EXECUTION_STARTED,
+    EVENT_LOG,
+)
+from pdip.integrator.initializer.integrator.default_integrator_initializer import (  # noqa: E402
+    DefaultIntegratorInitializer,
+)
+
+
+def _build_subject():
+    event_manager = MagicMock(name="event_manager")
+    event_manager_factory = MagicMock(name="event_manager_factory")
+    event_manager_factory.get.return_value = event_manager
+
+    execution_initializer = MagicMock(name="execution_initializer")
+    execution_initializer.initialize.side_effect = lambda operation, execution_id=None, ap_scheduler_job_id=None: operation  # noqa: E501
+    execution_initializer_factory = MagicMock(name="execution_initializer_factory")
+    execution_initializer_factory.get.return_value = execution_initializer
+
+    subject = DefaultIntegratorInitializer(
+        integrator_event_manager_factory=event_manager_factory,
+        execution_initializer_factory=execution_initializer_factory,
+    )
+    return subject, event_manager, execution_initializer
+
+
+class DefaultIntegratorInitializerInitialize(TestCase):
+    def test_broker_is_initialized_then_started(self):
+        subject, _event_manager, _init = _build_subject()
+        broker = MagicMock(name="broker")
+        call_order = []
+        broker.initialize.side_effect = lambda: call_order.append("initialize")
+        broker.start.side_effect = lambda: call_order.append("start")
+        operation = MagicMock(name="operation")
+
+        subject.initialize(operation=operation, message_broker=broker)
+
+        self.assertEqual(call_order, ["initialize", "start"])
+
+    def test_returns_the_operation_from_execution_initializer(self):
+        subject, _event_manager, execution_initializer = _build_subject()
+        broker = MagicMock(name="broker")
+        returned = MagicMock(name="returned_operation")
+        execution_initializer.initialize.side_effect = None
+        execution_initializer.initialize.return_value = returned
+        operation = MagicMock(name="operation")
+
+        result = subject.initialize(operation=operation, message_broker=broker)
+
+        self.assertIs(result, returned)
+
+    def test_passes_execution_and_scheduler_ids_to_inner_initializer(self):
+        subject, _event_manager, execution_initializer = _build_subject()
+        broker = MagicMock(name="broker")
+        operation = MagicMock(name="operation")
+
+        subject.initialize(
+            operation=operation,
+            message_broker=broker,
+            execution_id=77,
+            ap_scheduler_job_id=99,
+        )
+
+        execution_initializer.initialize.assert_called_once_with(
+            operation=operation,
+            execution_id=77,
+            ap_scheduler_job_id=99,
+        )
+
+
+class DefaultIntegratorInitializerRegistersAllEventListeners(TestCase):
+    def test_every_lifecycle_event_is_subscribed_exactly_once(self):
+        subject, event_manager, _init = _build_subject()
+        broker = MagicMock(name="broker")
+
+        subject.register_default_event_listeners(broker)
+
+        expected = {
+            EVENT_LOG: event_manager.log,
+            EVENT_EXECUTION_INITIALIZED: event_manager.initialize,
+            EVENT_EXECUTION_STARTED: event_manager.start,
+            EVENT_EXECUTION_FINISHED: event_manager.finish,
+            EVENT_EXECUTION_INTEGRATION_INITIALIZED: event_manager.integration_initialize,  # noqa: E501
+            EVENT_EXECUTION_INTEGRATION_STARTED: event_manager.integration_start,
+            EVENT_EXECUTION_INTEGRATION_FINISHED: event_manager.integration_finish,
+            EVENT_EXECUTION_INTEGRATION_EXECUTE_TRUNCATE: event_manager.integration_target_truncate,  # noqa: E501
+            EVENT_EXECUTION_INTEGRATION_EXECUTE_SOURCE: event_manager.integration_execute_source,  # noqa: E501
+            EVENT_EXECUTION_INTEGRATION_EXECUTE_TARGET: event_manager.integration_execute_target,  # noqa: E501
+        }
+        calls = broker.subscribe.call_args_list
+        registered = {call.args[0]: call.args[1] for call in calls}
+        self.assertEqual(registered, expected)

--- a/tests/unittests/integrator/initializer/test_execution_initializer_factory.py
+++ b/tests/unittests/integrator/initializer/test_execution_initializer_factory.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``ExecutionInitializerFactory``.
+
+The factory discovers ``ExecutionInitializer`` subclasses at call
+time and delegates resolution to the ``ServiceProvider``. We verify:
+
+* the default subclass is returned when it is the only registered one,
+* a custom subclass is preferred when present,
+* the provider is treated as a boundary (the factory calls ``get``
+  and forwards the resolved instance unchanged).
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.initializer.execution.base.default_execution_initializer import (  # noqa: E402
+    DefaultExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.base.execution_initializer import (  # noqa: E402
+    ExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.base.execution_initializer_factory import (  # noqa: E402
+    ExecutionInitializerFactory,
+)
+
+
+class ExecutionInitializerFactoryChoosesSubclass(TestCase):
+    def test_returns_default_when_it_is_the_only_subclass(self):
+        provider = MagicMock(name="service_provider")
+        sentinel = MagicMock(name="default_initializer")
+        provider.get.return_value = sentinel
+
+        factory = ExecutionInitializerFactory(service_provider=provider)
+        result = factory.get()
+
+        self.assertIs(result, sentinel)
+        provider.get.assert_called_once()
+
+    def test_prefers_custom_subclass_over_default(self):
+        class _Custom(ExecutionInitializer):
+            def initialize(self, operation, execution_id=None, ap_scheduler_job_id=None):
+                return operation
+
+        try:
+            provider = MagicMock(name="service_provider")
+            resolved = MagicMock(name="custom_initializer")
+            provider.get.return_value = resolved
+
+            factory = ExecutionInitializerFactory(service_provider=provider)
+            result = factory.get()
+
+            self.assertIs(result, resolved)
+            requested = provider.get.call_args[0][0]
+            self.assertIsNot(requested, DefaultExecutionInitializer)
+            self.assertTrue(issubclass(requested, ExecutionInitializer))
+        finally:
+            del _Custom

--- a/tests/unittests/integrator/initializer/test_operation_execution_initializer_factory.py
+++ b/tests/unittests/integrator/initializer/test_operation_execution_initializer_factory.py
@@ -1,0 +1,54 @@
+"""Unit tests for ``OperationExecutionInitializerFactory``.
+
+Same subclass-discovery pattern as ``IntegratorInitializerFactory``:
+pick the default when alone, prefer a custom subclass otherwise,
+delegate resolution to the ``ServiceProvider``.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.initializer.execution.operation.default_operation_execution_initializer import (  # noqa: E402
+    DefaultOperationExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.operation.operation_execution_initializer import (  # noqa: E402
+    OperationExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.operation.operation_execution_initializer_factory import (  # noqa: E402
+    OperationExecutionInitializerFactory,
+)
+
+
+class OperationExecutionInitializerFactoryChoosesSubclass(TestCase):
+    def test_returns_default_when_it_is_the_only_subclass(self):
+        provider = MagicMock(name="service_provider")
+        sentinel = MagicMock(name="default_initializer")
+        provider.get.return_value = sentinel
+
+        factory = OperationExecutionInitializerFactory(service_provider=provider)
+        result = factory.get()
+
+        self.assertIs(result, sentinel)
+        provider.get.assert_called_once()
+
+    def test_prefers_custom_subclass_over_default(self):
+        class _Custom(OperationExecutionInitializer):
+            def initialize(self, operation):
+                return operation
+
+        try:
+            provider = MagicMock(name="service_provider")
+            resolved = MagicMock(name="custom_initializer")
+            provider.get.return_value = resolved
+
+            factory = OperationExecutionInitializerFactory(service_provider=provider)
+            result = factory.get()
+
+            self.assertIs(result, resolved)
+            requested = provider.get.call_args[0][0]
+            self.assertIsNot(requested, DefaultOperationExecutionInitializer)
+            self.assertTrue(issubclass(requested, OperationExecutionInitializer))
+        finally:
+            del _Custom

--- a/tests/unittests/integrator/initializer/test_operation_integration_execution_initializer_factory.py
+++ b/tests/unittests/integrator/initializer/test_operation_integration_execution_initializer_factory.py
@@ -1,0 +1,61 @@
+"""Unit tests for ``OperationIntegrationExecutionInitializerFactory``.
+
+Same subclass-discovery pattern as its peer factories: default when
+alone, custom preferred otherwise, provider is the boundary.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.initializer.execution.integration.default_operation_integration_execution_initializer import (  # noqa: E402
+    DefaultOperationIntegrationExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.integration.operation_integration_execution_initializer import (  # noqa: E402
+    OperationIntegrationExecutionInitializer,
+)
+from pdip.integrator.initializer.execution.integration.operation_integration_execution_initializer_factory import (  # noqa: E402
+    OperationIntegrationExecutionInitializerFactory,
+)
+
+
+class OperationIntegrationExecutionInitializerFactoryChoosesSubclass(TestCase):
+    def test_returns_default_when_it_is_the_only_subclass(self):
+        provider = MagicMock(name="service_provider")
+        sentinel = MagicMock(name="default_initializer")
+        provider.get.return_value = sentinel
+
+        factory = OperationIntegrationExecutionInitializerFactory(
+            service_provider=provider
+        )
+        result = factory.get()
+
+        self.assertIs(result, sentinel)
+        provider.get.assert_called_once()
+
+    def test_prefers_custom_subclass_over_default(self):
+        class _Custom(OperationIntegrationExecutionInitializer):
+            def initialize(self, operation_integration):
+                return operation_integration
+
+        try:
+            provider = MagicMock(name="service_provider")
+            resolved = MagicMock(name="custom_initializer")
+            provider.get.return_value = resolved
+
+            factory = OperationIntegrationExecutionInitializerFactory(
+                service_provider=provider
+            )
+            result = factory.get()
+
+            self.assertIs(result, resolved)
+            requested = provider.get.call_args[0][0]
+            self.assertIsNot(
+                requested, DefaultOperationIntegrationExecutionInitializer
+            )
+            self.assertTrue(
+                issubclass(requested, OperationIntegrationExecutionInitializer)
+            )
+        finally:
+            del _Custom

--- a/tests/unittests/integrator/integration/test_integration_adapter_factory.py
+++ b/tests/unittests/integrator/integration/test_integration_adapter_factory.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``IntegrationAdapterFactory``.
+
+``get`` picks between a target-only adapter and a source-to-target
+adapter based on the ``IntegrationBase`` shape:
+
+* no target name -> hard ``Exception``,
+* target-only (no source name) -> ``target_integration`` (if compatible),
+* source and target both present -> ``source_to_target_integration``
+  (guarded by an ``isinstance`` check on ``source_integration``).
+
+Note: the ``else`` branch tests compatibility of ``source_integration``
+but returns ``source_to_target_integration`` — we pin that odd
+behaviour as a **real bug noted** rather than a silent accident.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.exceptions import IncompatibleAdapterException  # noqa: E402
+from pdip.integrator.integration.domain.base import IntegrationBase  # noqa: E402
+from pdip.integrator.integration.types.base import (  # noqa: E402
+    IntegrationAdapter,
+    IntegrationAdapterFactory,
+)
+
+
+class _TargetConn:
+    def __init__(self, name):
+        self.ConnectionName = name
+
+
+def _make_integration(target_name, source_name=None):
+    target = _TargetConn(target_name) if target_name is not None else None
+    source = _TargetConn(source_name) if source_name is not None else None
+    integration = IntegrationBase()
+    integration.TargetConnections = target
+    integration.SourceConnections = source
+    return integration
+
+
+def _build_factory(source=None, target=None, source_to_target=None):
+    return IntegrationAdapterFactory(
+        source_integration=source
+        if source is not None
+        else MagicMock(spec=IntegrationAdapter),
+        target_integration=target
+        if target is not None
+        else MagicMock(spec=IntegrationAdapter),
+        source_to_target_integration=source_to_target
+        if source_to_target is not None
+        else MagicMock(spec=IntegrationAdapter),
+    )
+
+
+class IntegrationAdapterFactoryRoutesByShape(TestCase):
+    def test_missing_target_connections_raises(self):
+        factory = _build_factory()
+        integration = IntegrationBase()
+        integration.TargetConnections = None
+
+        with self.assertRaises(Exception) as ctx:
+            factory.get(integration)
+
+        self.assertIn("Target connection required", str(ctx.exception))
+
+    def test_target_connections_without_name_raises(self):
+        factory = _build_factory()
+        integration = _make_integration(target_name=None)
+        # Replace the None TargetConnections with an object whose
+        # ``ConnectionName`` is None so we take the second half of
+        # the guard.
+        integration.TargetConnections = _TargetConn(None)
+
+        with self.assertRaises(Exception) as ctx:
+            factory.get(integration)
+
+        self.assertIn("Target connection required", str(ctx.exception))
+
+    def test_target_only_integration_returns_target_adapter(self):
+        target = MagicMock(spec=IntegrationAdapter, name="target")
+        factory = _build_factory(target=target)
+        integration = _make_integration(target_name="T")
+
+        result = factory.get(integration)
+
+        self.assertIs(result, target)
+
+    def test_source_and_target_returns_source_to_target_adapter(self):
+        source_to_target = MagicMock(spec=IntegrationAdapter, name="s2t")
+        factory = _build_factory(source_to_target=source_to_target)
+        integration = _make_integration(target_name="T", source_name="S")
+
+        result = factory.get(integration)
+
+        self.assertIs(result, source_to_target)
+
+
+class IntegrationAdapterFactoryRejectsIncompatibleAdapters(TestCase):
+    def test_target_only_with_incompatible_target_raises(self):
+        factory = _build_factory(target=object())
+        integration = _make_integration(target_name="T")
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get(integration)
+
+    def test_source_and_target_with_incompatible_source_raises(self):
+        # NOTE: the factory checks ``source_integration`` via isinstance
+        # but *returns* ``source_to_target_integration``. The negative
+        # path is still reachable because the isinstance guard is on
+        # ``source_integration``.
+        factory = _build_factory(source=object())
+        integration = _make_integration(target_name="T", source_name="S")
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get(integration)

--- a/tests/unittests/integrator/integration/test_integration_execute_strategy_factory.py
+++ b/tests/unittests/integrator/integration/test_integration_execute_strategy_factory.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``IntegrationSourceToTargetExecuteStrategyFactory``.
+
+The factory picks between the single-process and parallel-thread
+strategies based on the ``process_count`` argument:
+
+* ``None`` or ``<= 1`` -> single-process strategy,
+* ``> 1``              -> parallel-thread strategy.
+
+Compatibility with the abstract ``IntegrationSourceToTargetExecuteStrategy``
+is enforced by an ``isinstance`` guard on both branches.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.exceptions import IncompatibleAdapterException  # noqa: E402
+from pdip.integrator.integration.types.sourcetotarget.strategies.base import (  # noqa: E402
+    IntegrationSourceToTargetExecuteStrategy,
+)
+from pdip.integrator.integration.types.sourcetotarget.strategies.factories.integration_execute_strategy_factory import (  # noqa: E402
+    IntegrationSourceToTargetExecuteStrategyFactory,
+)
+
+
+def _build_factory(parallel=None, single=None):
+    parallel = (
+        parallel
+        if parallel is not None
+        else MagicMock(spec=IntegrationSourceToTargetExecuteStrategy, name="parallel")
+    )
+    single = (
+        single
+        if single is not None
+        else MagicMock(spec=IntegrationSourceToTargetExecuteStrategy, name="single")
+    )
+    return IntegrationSourceToTargetExecuteStrategyFactory(
+        parallel_thread_integration_execute=parallel,
+        single_process_integration_execute=single,
+    )
+
+
+class StrategyFactoryRoutesByProcessCount(TestCase):
+    def test_none_process_count_selects_single_process(self):
+        single = MagicMock(spec=IntegrationSourceToTargetExecuteStrategy, name="s")
+        factory = _build_factory(single=single)
+
+        result = factory.get(process_count=None)
+
+        self.assertIs(result, single)
+
+    def test_process_count_one_selects_single_process(self):
+        single = MagicMock(spec=IntegrationSourceToTargetExecuteStrategy, name="s")
+        factory = _build_factory(single=single)
+
+        result = factory.get(process_count=1)
+
+        self.assertIs(result, single)
+
+    def test_process_count_greater_than_one_selects_parallel(self):
+        parallel = MagicMock(spec=IntegrationSourceToTargetExecuteStrategy, name="p")
+        factory = _build_factory(parallel=parallel)
+
+        result = factory.get(process_count=4)
+
+        self.assertIs(result, parallel)
+
+
+class StrategyFactoryRejectsIncompatibleStrategies(TestCase):
+    def test_parallel_slot_incompatible_raises_when_process_count_exceeds_one(self):
+        factory = _build_factory(parallel=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get(process_count=2)
+
+    def test_single_slot_incompatible_raises_when_process_count_is_one(self):
+        factory = _build_factory(single=object())
+
+        with self.assertRaises(IncompatibleAdapterException):
+            factory.get(process_count=1)


### PR DESCRIPTION
## Summary

Closes coverage gaps on the integrator factories and initializers with **42 behavioural tests**. Factory subtree aggregate: **92 %** (323 stmts, 27 missed). Three real bugs surfaced during test writing — flagged, pinned by tests, not fixed.

## Coverage delta

| Module | Before | Tests | After |
|---|---|---|---|
| `pdip/integrator/connection/factories/connection_target_adapter_factory.py` | 30 % | 10 | **85 %** |
| `pdip/integrator/connection/factories/connection_source_adapter_factory.py` | 33 % | 9 | **89 %** |
| `pdip/integrator/initializer/integrator/default_integrator_initializer.py` | 42 % | 4 | **100 %** |
| `pdip/integrator/integration/types/base/integration_adapter_factory.py` | 50 % | 6 | **100 %** |
| `pdip/integrator/integration/types/sourcetotarget/strategies/factories/integration_execute_strategy_factory.py` | 53 % | 5 | **100 %** |
| `pdip/integrator/initializer/execution/operation/operation_execution_initializer_factory.py` | 50 % | 2 | **100 %** |
| `pdip/integrator/initializer/execution/integration/operation_integration_execution_initializer_factory.py` | 50 % | 2 | **94 %** |
| `pdip/integrator/initializer/execution/base/execution_initializer_factory.py` | 50 % | 2 | **100 %** |
| `pdip/integrator/event/base/integrator_event_manager_factory.py` | 50 % | 2 | **94 %** |

Quality guard (ADR-0026) stays green. Suite 309 → **351** tests. Repo coverage: **86 % → 89 %**.

## Skipped / boundary-capped paths

- `connection_*_adapter_factory.py` lines 36–38 / 42–44 / 60–62 — the `File` / `Queue` / `InMemory` branches reference attributes that `__init__` never sets (see bug #1 / #2 below). Tests pin the **current** `AttributeError` behaviour so a future fix has to update the test.
- Default execution initializers (`DefaultExecutionInitializer`, `Default{Operation,OperationIntegration}ExecutionInitializer`) are Pdi-bound — exercised through the DI container and the `basic_app_*` suites. Not the target of this PR.

## Bugs noticed, not fixed (pinned by tests; separate PR)

1. **`ConnectionTargetAdapterFactory.get_adapter`** reads `self.file_target_adapter`, `self.queue_target_adapter`, `self.in_memory_target_adapter` — none of which `__init__` assigns. Calling with `ConnectionTypes.File` / `Queue` / `InMemory` raises `AttributeError` instead of the documented `IncompatibleAdapterException` / `NotSupportedFeatureException`.
2. **`ConnectionSourceAdapterFactory`** has the same issue for `File` / `Queue`.
3. **`IntegrationAdapterFactory.get`** — the two-connection branch guards `isinstance(self.source_integration, IntegrationAdapter)` but **returns** `self.source_to_target_integration`. The guard checks a different object than the one returned.

## Files added

- `tests/unittests/integrator/connection/factories/test_connection_target_adapter_factory.py` (+ `__init__.py`)
- `tests/unittests/integrator/connection/factories/test_connection_source_adapter_factory.py`
- `tests/unittests/integrator/initializer/test_default_integrator_initializer.py`
- `tests/unittests/integrator/initializer/test_execution_initializer_factory.py`
- `tests/unittests/integrator/initializer/test_operation_execution_initializer_factory.py`
- `tests/unittests/integrator/initializer/test_operation_integration_execution_initializer_factory.py`
- `tests/unittests/integrator/integration/test_integration_adapter_factory.py`
- `tests/unittests/integrator/integration/test_integration_execute_strategy_factory.py`
- `tests/unittests/integrator/event/test_integrator_event_manager_factory.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_