### PR TITLE
chore(coverage): ratchet floor 30 → 95 (measured 95% across 508 tests)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,9 +9,11 @@ source = pdip
 branch = False
 
 [report]
-# Floor ratcheted from 20 to 30 per ADR-0023 — see the ratchet policy
-# in that ADR for the rules governing this number.
-fail_under = 30
+# Floor ratcheted 30 -> 95 per ADR-0023 after the coverage-to-95 push
+# (PRs #72, #73, #74, #75, #76 + the earlier #67-#71 and #66). Measured
+# coverage at the time of this ratchet was 95 % across 508 unit tests.
+# Ratchet rounds down to the nearest 5.
+fail_under = 95
 show_missing = True
 skip_empty = True
 skip_covered = False

--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test with unittest and coverage
         run: |
           coverage run run_tests.py
-          coverage report -m --fail-under=30
+          coverage report -m --fail-under=95
           coverage xml
           coverage html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ for the public API surface described in
 
 ## [Unreleased]
 
+### Changed
+
+- **Coverage floor ratcheted 30 → 95 %** per ADR-0023. Measured
+  coverage at the time of the ratchet was **95 %** across **508**
+  unit tests, lifted by the `.coveragerc` path correction (#71,
+  47 → 68 %) plus nine parallel test-writing PRs (#67, #68, #69,
+  #70, #72/#76, #73, #74, #75) that covered 33 previously untested
+  or partially tested modules. 3 tests skipped on Python 3.14+
+  where `typing.Union`'s representation changed (see the respective
+  PR bodies); the `TypeChecker` stale-code bug is flagged for a
+  separate PR.
+
 ### Added
 
 - **ADR-0026 — Test quality rules.** Every test asserts a concrete


### PR DESCRIPTION
## Summary

Ratchets `.coveragerc`'s `fail_under` from **30 → 95 %** and updates the CI workflow to match. Measured coverage at the time of this ratchet is **95 %** across **508** unit tests.

ADR-0023's ratchet rule is "round down to the nearest 5, monotonic". 95 is the right number.

## Lift came from

| PR | Impact |
|---|---|
| #71 | Corrected adapter-exclusion globs in `.coveragerc` (typo: missing `types/`). Reflected ADR-0023's intent. **47 % → 68 %** with no new tests. |
| #67 | `cqrs/generator/query_generator.py` **0 → 100 %** (+28 tests). |
| #68 | `html` + `delivery` + `io` (+42 tests, three modules at 100 %, one at 91 %). |
| #69 | Integrator non-adapter bases (+60 tests, 97–100 %). |
| #70 | API specs + `data.seed` + `config.services` + pub-sub workers (+62 tests, cluster 96 %). |
| #76 | `json` + `logging` + `utils` (+53 tests, 70 → 98 %). |
| #73 | Integrator factories + initializers (+42 tests, subtree 92 %). |
| #74 | Processing + singleprocess + inmemory config (+33 tests, block 98 %). |
| #75 | `endpoint_wrapper` + `module_finder` + pub-sub lifecycle + integrator target/event (+71 tests, 99–100 %). |

## Quality posture

All 508 tests follow **ADR-0026** (behavioural assertions, AAA, `unittest`-only, no `Pdi()` boot, no `time.sleep(N) >= 0.1 s`, mocks at boundaries). The quality-guard meta-test under `tests/unittests/quality_guard/` still enforces the five machine-checkable rules on every PR.

## Bugs noticed during the push (flagged, pinned by tests, not fixed)

Each of these is tracked for a separate bug-fix PR:

- `pdip/utils/type_checker.py:41` references the removed `typing._Protocol`.
- `pdip/logging/loggers/sql/sql_logger.py:51–57` double-prefixes `job_id` on DB failure.
- `pdip/cqrs/generator/query_generator.py:108,110` tabs vs spaces in generated Response file.
- `pdip/integrator/integration/types/source/base/source_integration.py:59,74` — duplicate `BigData` branch (WebService finish path dead) and `if` vs `elif` override.
- `pdip/integrator/integration/types/sourcetotarget/base/source_to_target_integration.py:98,113` — same pattern.
- `pdip/integrator/event/base/default_integrator_event_manager.py:75` — unconditional `time.sleep(2)`.
- `pdip/integrator/connection/factories/connection_target_adapter_factory.py` and `connection_source_adapter_factory.py` — `File`/`Queue`/`InMemory` branches read attributes `__init__` never sets → `AttributeError` instead of the documented exceptions.
- `pdip/integrator/integration/types/base/integration_adapter_factory.py` — guard on `source_integration` but returns `source_to_target_integration`.
- `pdip/html/html_template_service.py:246–260` — dead pagination branch referencing missing `Pagination` attributes.
- `pdip/api/handlers/error_handlers.py:62,85` — "Messsage" typo (three s's).
- `pdip/api/handlers/error_handlers.py:69–85` — re-declares `separator` / `default_content_type` / `mime_type_string` as locals.
- `pdip/data/seed/seed_runner.py:31–32` — fallback `seed()` call outside the try/except.

## Verified

- **Python 3.11**: 508/508 green, `coverage report --fail-under=95` passes (measured 95 %).
- **Python 3.14**: same 508/508 green; 3 tests deliberately skipped via `@unittest.skipIf` where `typing.Union`'s representation changed (documented in PR #76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_