### PR TITLE
ADR-0027: TDD + diff-coverage CI gate (100 % on changed lines)

### DIFF
--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -20,6 +20,10 @@ jobs:
         python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # diff-cover needs the merge-base to exist locally so it can
+          # compute "lines changed since main" on pull-request builds.
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -42,6 +46,24 @@ jobs:
           coverage report -m --fail-under=95
           coverage xml
           coverage html
+
+      - name: Enforce 100 % diff coverage on changed lines (ADR-0027)
+        # Runs only on pull requests, on one matrix cell (avoids
+        # duplicate diff reports from every Python × OS combination).
+        # diff-cover compares coverage.xml against the PR's merge-base
+        # with ``origin/main``; the --fail-under=100 gate fails CI if
+        # any new or modified pdip/ line is uncovered. The override
+        # pattern for tests/config is implicit — those files are not
+        # in coverage.xml to begin with.
+        if: >
+          github.event_name == 'pull_request'
+          && matrix.python == '3.11'
+          && matrix.os == 'ubuntu-latest'
+        run: |
+          git fetch origin "${GITHUB_BASE_REF:-main}" --depth=100
+          diff-cover coverage.xml \
+            --compare-branch "origin/${GITHUB_BASE_REF:-main}" \
+            --fail-under=100
 
       - name: Upload coverage artifacts
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ for the public API surface described in
 
 ## [Unreleased]
 
+### Added
+
+- **ADR-0027 — Test-first development (TDD) with diff-coverage
+  enforcement.** New production code in `pdip/` is written
+  test-first: write the failing test, watch it fail for the right
+  reason, then write the smallest change that makes it pass.
+  Machine enforcement via `diff-cover` in the CI workflow — every
+  PR must leave its newly added or modified `pdip/` lines at
+  **100 % line coverage**, measured against the merge-base with
+  `main`. Independent of the `fail_under` overall floor.
+- `quality_guard` gains a sixth machine-checked rule
+  (ADR-0027 §5): every `# pragma: no cover` must carry an inline
+  reason comment on the same line, or the guard fails.
+- `diff-cover==9.2.0` added to `requirements.txt`.
+
 ### Changed
 
 - **Coverage floor ratcheted 30 → 95 %** per ADR-0023. Measured

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,14 @@ Before proposing architecturally significant changes, read the relevant
   [governance README](docs/governance/README.md).
 - Tests follow the quality rules in
   [ADR-0026](docs/governance/adr/0026-test-quality-rules.md). Every
-  test asserts a concrete behaviour; five of the rules are
+  test asserts a concrete behaviour; six of the rules are
   machine-enforced by `tests/unittests/quality_guard/` and will fail
   CI when violated.
+- **New production code is written test-first**
+  ([ADR-0027](docs/governance/adr/0027-tdd-with-diff-coverage.md)).
+  Diff-coverage enforces this mechanically: every PR must leave
+  its newly added or modified `pdip/` lines at 100 % line coverage,
+  measured against the merge-base with `main`. CI fails otherwise.
 
 ## How Can I Contribute?
 

--- a/docs/governance/adr/0027-tdd-with-diff-coverage.md
+++ b/docs/governance/adr/0027-tdd-with-diff-coverage.md
@@ -1,0 +1,204 @@
+# ADR-0027: Test-first development (TDD) with diff-coverage enforcement
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Deciders:** pdip maintainers
+- **Tags:** testing, ci, quality, process
+- **Extends:** [ADR-0018](./0018-testing-strategy.md) (testing strategy),
+  [ADR-0023](./0023-coverage-floor-policy.md) (coverage floor),
+  [ADR-0026](./0026-test-quality-rules.md) (test quality rules)
+
+## Context
+
+The repository's coverage floor has ratcheted from "uncollected" →
+20 % → 30 % → 95 %. At 95 %, further progress **by raw test volume
+alone** starts to erode quality:
+
+- Writing tests *after* the code tends to rubber-stamp the
+  implementation — the test reflects what the code does, not what
+  the behaviour should be.
+- Coverage-chasing after the fact rewards volume over meaning.
+  ADR-0026 codifies behavioural-assertion rules; combining those
+  with test-first removes the "cover this last line" trap.
+- At 95 %, the remaining 5 % is exactly the code most likely to
+  hide bugs: defensive guards, error paths, dead branches from
+  earlier bugs. Test-first forces a reader to ask "what is the
+  expected behaviour here?" before accepting the implementation.
+
+The natural next step is **TDD** — write the failing test first,
+then the implementation that makes it pass — and enforce it
+mechanically where possible.
+
+## Decision
+
+### 1. TDD is the default workflow for new production code
+
+When adding or modifying a public behaviour in `pdip/`:
+
+1. **Write the failing test first.** The test should describe the
+   behaviour in its name and assert it in its body (ADR-0026 rules
+   apply verbatim).
+2. **Run the test and confirm it fails for the right reason** —
+   either the code does not exist yet, or the current code does
+   the wrong thing. A test that passes against unchanged code is
+   not TDD.
+3. **Write the smallest change that makes the test pass.** No
+   extra behaviour; no speculative hooks.
+4. **Refactor** if needed; every test must keep passing.
+5. **Commit.** Each commit is either red-green (new failing test
+   + code that makes it pass) or pure refactor.
+
+### 2. Exceptions
+
+TDD is not required for:
+
+- Pure configuration changes (YAML, env defaults, CI workflows,
+  ADR documents).
+- Test fixtures and test helper code (the tests themselves ARE
+  the specification).
+- Trivial rename / reformat refactors that do not change behaviour
+  (but the test must exist and keep passing).
+- Bug fixes where a test already exists that pins the current bad
+  behaviour; update the test first to assert the desired behaviour,
+  watch it fail, then fix the code (this is still test-first).
+
+Everything else that touches `pdip/` follows TDD.
+
+### 3. Machine enforcement — diff-coverage
+
+ADR-0023's `fail_under` enforces total coverage. It does **not**
+catch a PR that leaves its own new lines untested. We add a second
+gate:
+
+- `diff-cover` (or an equivalent tool) is added to CI.
+- Every PR runs `diff-cover` against `origin/main`. The tool
+  reports the coverage percentage **of lines changed in the PR**.
+- The CI step enforces **100 % diff coverage**: a PR whose newly
+  added or modified `pdip/` lines are not covered by the same PR's
+  test changes fails.
+- Test and config files (`tests/`, `*.yml`, `*.yaml`, `*.md`,
+  `*.cfg`, `*.toml`, `.coveragerc`, `.gitignore`) are excluded
+  from the diff-coverage numerator.
+
+This means: a PR that adds a new method to a service class without
+a test for it fails CI, even if the overall floor stays at 95 %.
+
+### 4. Machine enforcement — test-first signal
+
+A perfectly rigorous "the test commit is older than the
+implementation commit" check is brittle (rebases, squash merges
+rewrite history). We approximate it:
+
+- Every PR's commit graph must contain **at least one commit whose
+  diff adds a `test_*` method or a new `Test*` class** before any
+  commit that grows the statement count of `pdip/`. `diff-cover`'s
+  100 % gate catches the outcome; this ordering check is a soft
+  reviewer signal, not a CI hard-fail. If a PR's history is
+  squashed before merge, the ordering evidence lives in the PR's
+  commit list rather than the final `main` history.
+- Reviewers are expected to ask "is there a commit here where the
+  test fails without the impl?" when the ordering is not obvious.
+
+### 5. 100 % overall coverage as the new target
+
+With diff-coverage in place and the quality-guard rules from
+ADR-0026 already enforced, **overall coverage can be raised to
+100 %** safely:
+
+- No vanity tests get past review (ADR-0026 A.2, E.1).
+- No uncovered new line gets past CI (diff-cover).
+- No silent fail (ADR-0018 exit-code gate).
+- Unreachable defensive code that cannot be triggered from outside
+  is marked with `# pragma: no cover` and a **one-line comment
+  explaining why** on the same line. The guard refuses a pragma
+  without a comment.
+
+The ratchet to 100 happens in its own PR after the existing
+flagged bugs are fixed (they are the cause of most of today's 5 %
+gap).
+
+### 6. Review expectations
+
+Reviewers check, in order:
+
+1. The PR contains a test that describes the new behaviour and
+   (at some commit) fails against the unchanged code.
+2. CI is green — including `diff-cover` at 100 %.
+3. Every `# pragma: no cover` added in the PR has a one-line
+   reason comment on the same line.
+4. ADR-0026 rules hold (quality_guard already covers the
+   machine-checkable ones).
+
+## Consequences
+
+### Positive
+
+- The "write tests second" trap that produces rubber-stamp tests
+  is closed.
+- Every new line ships with a test that describes its purpose.
+- The 100 % overall floor is defendable — it stops being "how much
+  code do we inspect?" and becomes "how much behaviour do we
+  specify?"
+- Agent-written code is subject to the same gate as human-written
+  code.
+
+### Negative
+
+- PR feedback loops include the diff-cover step; a forgotten test
+  fails CI.
+- Pragma hygiene is now part of review. Missed pragma comments
+  are a review nit reviewers have to catch until we build a guard
+  for them.
+- TDD is a habit, not a syntax rule. Review still carries the
+  ordering-signal check.
+
+### Neutral
+
+- The `fail_under` overall floor and the diff-cover PR gate are
+  independent mechanisms: one guards the body, one guards the
+  edges.
+
+## Alternatives considered
+
+### Option A — Stay at 95 %, no diff-cover
+
+- **Pro:** Zero new tooling.
+- **Con:** Any new module can drop the effective coverage of its
+  own file to 0 % without the total moving below 95 %.
+- **Why rejected:** Large additions create gaps the total hides.
+
+### Option B — Enforce mutation testing instead of TDD
+
+- **Pro:** Catches tests that do not actually assert the mutated
+  line.
+- **Con:** 10× more CI time, needs tool ramp-up, no equivalent
+  "write the test first" push.
+- **Why rejected:** Worth considering later; TDD+diff-cover
+  covers the day-one concern.
+
+### Option C — Require a literal `test-*` commit before an `impl-*`
+commit
+
+- **Pro:** Objective.
+- **Con:** Squash-merge and rebase rewrite history; does not
+  survive merge. Makes local workflow rigid without clear payoff.
+- **Why rejected:** Soft reviewer signal is enough; diff-cover
+  is the hard gate.
+
+## Follow-ups
+
+- Bug-fix PR that closes the flagged dead-code causers so their
+  lines become legitimately coverable.
+- `# pragma: no cover`-with-comment guard added to
+  `tests/unittests/quality_guard/test_conventions.py`.
+- Ratchet PR that moves `fail_under` from 95 to 100.
+
+## References
+
+- [`.github/workflows/package-build-and-tests.yml`](../../../.github/workflows/package-build-and-tests.yml)
+  — `diff-cover` step added in the implementation PR.
+- [`.coveragerc`](../../../.coveragerc).
+- [ADR-0018](./0018-testing-strategy.md), [ADR-0023](./0023-coverage-floor-policy.md),
+  [ADR-0026](./0026-test-quality-rules.md).
+- [diff-cover](https://github.com/Bachmann1234/diff_cover) — the tool
+  the CI step uses.

--- a/docs/governance/adr/README.md
+++ b/docs/governance/adr/README.md
@@ -34,6 +34,7 @@ shapes how the framework is built and used. See the parent
 | [0024](./0024-release-process.md) | Release process — semver, CHANGELOG, and PyPI publish | Accepted | release, packaging, process |
 | [0025](./0025-dependabot-auto-merge-policy.md) | Dependabot auto-merge policy | Accepted | dependencies, ci, automation |
 | [0026](./0026-test-quality-rules.md) | Test quality rules | Accepted | testing, ci, quality |
+| [0027](./0027-tdd-with-diff-coverage.md) | Test-first development (TDD) with diff-coverage enforcement | Accepted | testing, ci, quality, process |
 
 ## Status legend
 

--- a/docs/governance/policies/README.md
+++ b/docs/governance/policies/README.md
@@ -79,10 +79,20 @@ disagree, the ADR is the source of truth and the policy must be updated.
   [ADR-0026](../adr/0026-test-quality-rules.md). Every test asserts a
   concrete behaviour; no tautologies; AAA structure; mocks at
   boundaries only; `unittest` only; no star imports; deterministic.
-  Five of the rules are machine-enforced by
+  Six of the rules are machine-enforced by
   `tests/unittests/quality_guard/test_conventions.py` — CI fails
   when they are violated. Reviewers enforce the rest with the ADR
   as the reference.
+- **TDD is the default workflow** for new production code
+  ([ADR-0027](../adr/0027-tdd-with-diff-coverage.md)). Write the
+  failing test first, watch it fail for the right reason, then
+  write the smallest change that makes it pass. Reviewers check
+  the commit graph for that ordering.
+- **Diff-coverage gates every PR at 100 %.** New or modified
+  `pdip/` lines must be covered by the same PR's test changes, or
+  CI fails — independent of the overall `fail_under` floor.
+- `# pragma: no cover` requires an inline reason comment on the
+  same line (the `quality_guard` meta-test enforces this).
 
 ## Review expectations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,3 +78,4 @@ nav:
           - ADR-0024 Release process: governance/adr/0024-release-process.md
           - ADR-0025 Dependabot auto-merge policy: governance/adr/0025-dependabot-auto-merge-policy.md
           - ADR-0026 Test quality rules: governance/adr/0026-test-quality-rules.md
+          - ADR-0027 TDD with diff-coverage: governance/adr/0027-tdd-with-diff-coverage.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage==7.6.12
+diff-cover==9.2.0
 cryptography==46.0.7
 dataclasses-json==0.6.7
 Flask==3.1.3

--- a/tests/unittests/quality_guard/test_conventions.py
+++ b/tests/unittests/quality_guard/test_conventions.py
@@ -243,3 +243,58 @@ class RuleF2NoStarImports(TestCase):
             "ADR-0026 F.2: no star imports in tests/. Offenders:\n  "
             + "\n  ".join(offenders),
         )
+
+
+# ---------------------------------------------------------------------------
+# Rule ADR-0027 §5 — ``# pragma: no cover`` must carry a one-line
+# reason comment on the same line (or the line immediately above it
+# when the pragma is on its own line).
+# ---------------------------------------------------------------------------
+
+
+_PRAGMA_NO_COVER_PATTERN = re.compile(r"#\s*pragma:\s*no\s+cover")
+
+
+def _has_pragma_reason(line: str) -> bool:
+    """True when a line with ``# pragma: no cover`` also carries an
+    explanatory comment immediately after the pragma on the same line,
+    e.g. ``foo = 1  # pragma: no cover — constructed only in prod``.
+
+    We look for any non-whitespace text after the ``no cover`` token
+    (other than a trailing closing parenthesis, a colon, a comma, or
+    line-continuation characters). A pragma that lives on its own line
+    with no explanation is rejected."""
+    match = _PRAGMA_NO_COVER_PATTERN.search(line)
+    if not match:
+        return True
+    tail = line[match.end():].strip()
+    # Strip punctuation characters that sometimes trail a pragma
+    # without adding meaning.
+    for ch in "():,;\\":
+        tail = tail.replace(ch, " ")
+    return bool(tail.strip())
+
+
+class RuleADR0027PragmaNoCoverHasReason(TestCase):
+    def test_every_pragma_no_cover_has_an_inline_reason(self):
+        offenders = []
+        src_root = _REPO_ROOT / "pdip"
+        for path in sorted(src_root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            for lineno, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if not _PRAGMA_NO_COVER_PATTERN.search(line):
+                    continue
+                if _has_pragma_reason(line):
+                    continue
+                rel = str(path.relative_to(_REPO_ROOT))
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+        self.assertEqual(
+            offenders,
+            [],
+            "ADR-0027 §5: every ``# pragma: no cover`` must carry an "
+            "inline reason comment on the same line. Offenders:\n  "
+            + "\n  ".join(offenders),
+        )


### PR DESCRIPTION
## Summary

Introduce **TDD as project policy** and wire a **mechanical gate** into CI so a PR cannot leave its own new lines uncovered. Sets the stage for the coverage-to-100 push.

## What changes

### ADR-0027 — Test-first development (TDD) with diff-coverage enforcement
- Write the failing test first, watch it fail for the right reason, write the smallest change that makes it pass.
- Exceptions documented (config-only PRs, test fixtures, trivial refactors, bug fixes that extend an existing failing test).
- Machine enforcement: `diff-cover` enforces **100 % coverage on lines changed in every PR**, measured against the merge-base with `main`. Independent of `fail_under`.
- Reviewer signal: commit graph should contain at least one "failing test" commit before the impl commit. Soft rule, not hard-failed in CI to survive squash/rebase.

### CI changes

- `actions/checkout@v4` now uses `fetch-depth: 0` so `diff-cover` can compute a merge-base diff on pull-request builds.
- New "Enforce 100 % diff coverage on changed lines (ADR-0027)" step runs on `pull_request` events from a single matrix cell (3.11 Ubuntu) so the diff report lands once per PR, not 18×. It fetches the base branch and runs `diff-cover coverage.xml --compare-branch origin/$BASE --fail-under=100`.

### quality_guard extension

- `RuleADR0027PragmaNoCoverHasReason`: every `# pragma: no cover` in `pdip/` must carry an inline reason comment on the same line. The guard rejects a bare `# pragma: no cover`.
- Total machine-checked rules: **6** (A.1, A.2, D.1, F.1, F.2, ADR-0027 §5).

### Governance

- ADR-0027 added; ADR index + mkdocs nav updated.
- `CONTRIBUTING.md` and `policies/README.md` reference the new TDD rule and the diff-coverage gate so contributors (and sub-agents) see it up front.
- `CHANGELOG.md` **Unreleased / Added** records the ADR, the guard rule, and the dependency.
- `requirements.txt` adds `diff-cover==9.2.0`.

## Verified

- **Python 3.11**: 509/509 green, `coverage report --fail-under=95` passes (95 %), quality_guard 6/6 green.
- **Python 3.14**: 509/509 green (3 tests skipped as before).

## Follow-ups (subsequent PRs)

- **Bug-fix PR** closing the ~12 flagged bugs — their dead code is most of today's 5 % gap.
- **Coverage-to-100 PR** — covers remaining legitimately coverable lines and adds `# pragma: no cover ` with inline reasons where genuinely unreachable.
- **Ratchet PR** moving `fail_under` to **100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_