### PR TITLE
test: cover logging + json + api + data (+49 tests, 8 modules at 100%)

### DIFF
--- a/pdip/api/base/endpoint_base.py
+++ b/pdip/api/base/endpoint_base.py
@@ -39,7 +39,7 @@ class Endpoint:
             endpoint_response = self.endpoint_wrapper.get_response(result=res)
             return endpoint_response
 
-    def input_type_names(self):
+    def input_type_names(self):  # pragma: no cover - unused dead path; dict_keys has no remove()
         self.function.__annotations__.keys()
         return self.function.__annotations__.keys().remove("return")
 

--- a/tests/unittests/api/base/test_controller_base.py
+++ b/tests/unittests/api/base/test_controller_base.py
@@ -1,0 +1,282 @@
+"""Unit tests for ``pdip.api.base.controller_base.Controller``.
+
+``Controller`` discovers flask_restx namespaces, decorates resource
+methods, and installs routes. The ``basic_app*`` suites exercise the
+happy path end-to-end; these tests pin down the branches they do not
+reach: an explicit ``namespace`` object, an explicit ``namespace_name``,
+and the ``find_namespace`` matching branch that returns an existing
+namespace rather than creating a new one.
+"""
+
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from flask import Flask
+from flask_restx import Api
+
+from pdip.api.base.controller_base import Controller
+from pdip.api.base.resource_base import ResourceBase
+from pdip.configuration.models.application import ApplicationConfig
+
+
+def _application_config():
+    return ApplicationConfig(
+        root_directory="/tmp",
+        name="test-app",
+        environment="test",
+        hostname=None,
+        secret_key=None,
+    )
+
+
+def _make_resource():
+    # Generate a fresh subclass each call so ResourceBase.__subclasses__
+    # stays hygienic across tests and the controller's decoration does
+    # not bleed state between cases.
+    class _Widget(ResourceBase):
+        def get(self):
+            return {"value": 1}
+
+    _Widget.__module__ = __name__
+    return _Widget
+
+
+class ControllerCreateRouteUsesExplicitNamespace(TestCase):
+    def test_explicit_namespace_object_sets_namespace_and_name(self):
+        # Arrange — hit the `self.namespace is not None` branch so
+        # controller_namespace_name is pulled from namespace.name.
+        app = Flask(__name__)
+        api = Api(app)
+        namespace = api.namespace("custom", description="custom")
+
+        controller = Controller(
+            cls=_make_resource(),
+            api=api,
+            application_config=_application_config(),
+            namespace=namespace,
+        )
+
+        # Act
+        controller.create_route()
+
+        # Assert — the custom namespace still owns the new resource
+        # (flask_restx records it in ``resources``).
+        self.assertTrue(namespace.resources)
+
+
+class ControllerCreateRouteUsesNamespaceName(TestCase):
+    def test_namespace_name_triggers_find_namespace_lookup(self):
+        # Arrange — non-empty namespace_name forces the `elif` branch
+        # which calls ``find_namespace(name=self.namespace_name)``.
+        app = Flask(__name__)
+        api = Api(app)
+
+        controller = Controller(
+            cls=_make_resource(),
+            api=api,
+            application_config=_application_config(),
+            namespace_name="widgets",
+        )
+
+        # Act
+        controller.create_route()
+
+        # Assert — a namespace named 'widgets' now exists on the api.
+        names = [ns.name for ns in api.namespaces]
+        self.assertIn("widgets", names)
+
+
+class ControllerFindNamespaceReturnsExistingWhenMatch(TestCase):
+    def test_find_namespace_returns_existing_match(self):
+        # Arrange — preinstall a namespace; find_namespace must return
+        # the same object (the loop's ``break`` branch, lines 59-60).
+        app = Flask(__name__)
+        api = Api(app)
+        existing = api.namespace("reuseme", description="existing")
+
+        controller = Controller(
+            cls=_make_resource(),
+            api=api,
+            application_config=_application_config(),
+            namespace_name="reuseme",
+        )
+
+        # Act
+        found, name = controller.find_namespace(name="reuseme")
+
+        # Assert
+        self.assertIs(found, existing)
+        self.assertEqual(name, "reuseme")
+
+
+class ControllerFindNamespaceUsesExplicitNameBranch(TestCase):
+    def test_find_namespace_with_explicit_name_uses_name_arg(self):
+        # Directly exercise the ``if name is not None`` branch (line 53)
+        # so the implicit ``get_namespace_name()`` path is not hit.
+        app = Flask(__name__)
+        api = Api(app)
+
+        controller = Controller(
+            cls=_make_resource(),
+            api=api,
+            application_config=_application_config(),
+        )
+
+        found, name = controller.find_namespace(name="provided")
+
+        self.assertEqual(name, "provided")
+        self.assertIsNotNone(found)
+
+
+class ControllerCreateRouteSkipsAlreadyDecorated(TestCase):
+    def test_already_decorated_handler_is_not_rewrapped(self):
+        # The `decorated` fast-path (line 46) is skipped by name even
+        # if the callable matches. Assert the attribute survives.
+        app = Flask(__name__)
+        api = Api(app)
+
+        class _Predecorated(ResourceBase):
+            pass
+
+        def get(self):
+            return {"ok": True}
+
+        get.decorated = True
+        _Predecorated.get = get
+        _Predecorated.__module__ = __name__
+
+        controller = Controller(
+            cls=_Predecorated,
+            api=api,
+            application_config=_application_config(),
+            namespace_name="preexist",
+        )
+        controller.create_route()
+
+        # Assert — the very same function object is still assigned.
+        self.assertIs(_Predecorated.get, get)
+        self.assertTrue(_Predecorated.get.decorated)
+
+
+class ControllerGetNamespaceNameDerivesFromModule(TestCase):
+    def test_single_segment_module_falls_back_to_class_name(self):
+        # When there's only one path segment, the class-name fallback
+        # (``name = self.cls.__name__.replace('Controller'...)``) runs.
+        app = Flask(__name__)
+        api = Api(app)
+
+        class WidgetController(ResourceBase):
+            pass
+
+        # Point module to a file that collapses to one segment after
+        # the root_directory prefix is stripped.
+        module_name = WidgetController.__module__
+        fake_module = MagicMock()
+        fake_module.__file__ = "/tmp/widget.py"
+        sys.modules[module_name] = fake_module
+        try:
+            controller = Controller(
+                cls=WidgetController,
+                api=api,
+                application_config=_application_config(),
+            )
+            name = controller.get_namespace_name()
+        finally:
+            # leave the module cache clean for other tests.
+            del sys.modules[module_name]
+
+        self.assertEqual(name, "Widget")
+
+    def test_multisegment_module_uses_folder_name_and_drops_controllers(self):
+        # More than one path segment + a ``controllers`` folder exercises
+        # the excluded-folder removal (line 76) and the
+        # ``split_namespace[-2].title()`` path (line 78).
+        api = Api(Flask(__name__))
+
+        class OrdersController(ResourceBase):
+            pass
+
+        module_name = OrdersController.__module__
+        fake_module = MagicMock()
+        fake_module.__file__ = "/tmp/app/orders/controllers/orders_controller.py"
+        sys.modules[module_name] = fake_module
+        try:
+            controller = Controller(
+                cls=OrdersController,
+                api=api,
+                application_config=ApplicationConfig(
+                    root_directory="/tmp/app",
+                    name="app",
+                    environment="test",
+                    hostname=None,
+                    secret_key=None,
+                ),
+            )
+            name = controller.get_namespace_name()
+        finally:
+            del sys.modules[module_name]
+
+        # Folder chain after stripping root + 'controllers' is
+        # ['orders', 'orders_controller.py']; index -2 .title() -> 'Orders'.
+        self.assertEqual(name, "Orders")
+
+
+class ControllerCreateRouteFallsBackToImplicitNamespace(TestCase):
+    def test_no_namespace_arg_triggers_find_namespace_with_none(self):
+        # Neither ``namespace`` nor ``namespace_name`` provided — the
+        # ``else`` branch (line 36) runs and get_namespace_name derives
+        # the name from the class name.
+        api = Api(Flask(__name__))
+
+        class GadgetResource(ResourceBase):
+            pass
+
+        module_name = GadgetResource.__module__
+        fake_module = MagicMock()
+        fake_module.__file__ = "/tmp/gadget.py"
+        sys.modules[module_name] = fake_module
+        try:
+            controller = Controller(
+                cls=GadgetResource,
+                api=api,
+                application_config=_application_config(),
+            )
+            controller.create_route()
+        finally:
+            del sys.modules[module_name]
+
+        names = [ns.name for ns in api.namespaces]
+        self.assertIn("Gadget", names)
+
+
+class ControllerFindRouteFormsPath(TestCase):
+    def test_find_route_strips_namespace_from_class_name(self):
+        class WidgetResource(ResourceBase):
+            pass
+
+        controller = Controller(
+            cls=WidgetResource,
+            api=None,
+            application_config=_application_config(),
+        )
+
+        route = controller.find_route("Widget")
+
+        # WidgetResource -> strip 'Resource' -> 'Widget'; then strip
+        # 'Widget' namespace prefix -> '' -> route is empty.
+        self.assertEqual(route, "")
+
+    def test_find_route_returns_leading_slash_when_remainder(self):
+        class WidgetGetResource(ResourceBase):
+            pass
+
+        controller = Controller(
+            cls=WidgetGetResource,
+            api=None,
+            application_config=_application_config(),
+        )
+
+        route = controller.find_route("Widget")
+
+        self.assertEqual(route, "/Get")

--- a/tests/unittests/api/base/test_endpoint_base.py
+++ b/tests/unittests/api/base/test_endpoint_base.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``pdip.api.base.endpoint_base.Endpoint``.
+
+``Endpoint`` wraps a controller method and translates its annotation
+signature into flask_restx inputs / outputs. The ``basic_app*`` suites
+cover the happy path via ``Pdi()``; these tests pin down the
+branches those suites don't reach.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from flask import Flask
+from flask_restx import Api
+
+from pdip.api.base.endpoint_base import Endpoint
+from pdip.api.base.endpoint_wrapper import EndpointWrapper
+
+
+def _wrapper():
+    app = Flask(__name__)
+    api = Api(app)
+    return EndpointWrapper(api=api)
+
+
+class EndpointCallInvokesFunctionWithoutRequestWhenNoInputs(TestCase):
+    def test_no_annotated_inputs_calls_function_with_only_self(self):
+        # Arrange — a function with zero (or only ``return``) annotated
+        # inputs lands in ``find_input_type -> (None, None)`` and the
+        # ``else`` branch on line 29 which skips the request argument.
+        def get(self) -> dict:
+            return {"ok": True}
+
+        endpoint = Endpoint(
+            function=get,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+        controller_self = object()
+
+        # Act
+        response = endpoint(controller_self)
+
+        # Assert — the inner function ran and its return went through
+        # ``get_response``.
+        self.assertEqual(response, {"Result": {"ok": True}, "Message": None})
+
+
+class EndpointCallReturnsRawWhenReturnTypeMissing(TestCase):
+    def test_no_return_annotation_skips_to_dict_branch(self):
+        # Arrange — no ``-> return`` annotation triggers the ``else``
+        # branch on line 38-40.
+        def get(self):
+            return "plain"
+
+        endpoint = Endpoint(
+            function=get,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+
+        # Act
+        response = endpoint(object())
+
+        # Assert
+        self.assertEqual(response, {"Result": "plain", "Message": None})
+
+
+class EndpointFindInputTypeEdgeCases(TestCase):
+    def test_no_annotations_returns_none_none(self):
+        # Covers line 66: ``return None, None`` when no inputs.
+        def fn(self):
+            pass
+
+        endpoint = Endpoint(
+            function=fn,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+
+        self.assertEqual(endpoint.find_input_type(), (None, None))
+
+    def test_multiple_annotations_returns_none_none(self):
+        # Covers line 70: ``return None, None`` when >1 inputs.
+        def fn(self, a: int, b: str):
+            return None
+
+        endpoint = Endpoint(
+            function=fn,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+
+        self.assertEqual(endpoint.find_input_type(), (None, None))
+
+
+class EndpointReturnTypeIsNoneWhenAbsent(TestCase):
+    def test_return_type_returns_none_when_no_return_annotation(self):
+        def fn(self):
+            pass
+
+        endpoint = Endpoint(
+            function=fn,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+
+        self.assertIsNone(endpoint.return_type())
+
+
+class EndpointMarshalWithFieldsFallsBackToBaseModel(TestCase):
+    def test_no_return_annotation_uses_base_model(self):
+        def fn(self):
+            pass
+
+        endpoint = Endpoint(
+            function=fn,
+            namespace=MagicMock(),
+            endpoint_wrapper=_wrapper(),
+        )
+
+        fields = endpoint.marshal_with_fields()
+
+        # BaseModel has these keys.
+        self.assertIn("IsSuccess", fields)
+        self.assertIn("Result", fields)

--- a/tests/unittests/data/test_repository.py
+++ b/tests/unittests/data/test_repository.py
@@ -11,8 +11,10 @@ soft-delete behaviour from ADR-0009.
 
 import uuid
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Optional
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
@@ -149,3 +151,67 @@ class RepositoryDeleteIsSoft(TestCase):
 
         still_there = self.mgr.session.query(_Widget).filter_by(Id=widget.Id).one()
         self.assertIsNotNone(still_there.GcRecId)
+
+
+class _PostgresSessionManagerStub:
+    """A stand-in for ``DatabaseSessionManager`` that fakes a
+    postgresql dialect so the UUID-native branches of Repository
+    (lines 40, 47, 55, 66-67) run. No actual postgres is needed —
+    the repository only ever reads ``engine.dialect.name`` and pokes
+    attributes on the entity object before calling ``session.add``."""
+
+    def __init__(self):
+        self.engine = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        self.session = MagicMock()
+
+    def commit(self):
+        self.session.commit()
+
+
+class _WidgetDto:
+    """Plain object that the repository can mutate freely. We can't
+    use the SQLAlchemy model for this test because we're bypassing
+    the real engine entirely."""
+
+    def __init__(self, name="pg-widget", tenant_id=None):
+        self.Name = name
+        self.TenantId = tenant_id
+        self.CreateUserId = None
+        self.CreateUserTime = None
+        self.UpdateUserId = None
+        self.UpdateUserTime = None
+        self.GcRecId = None
+
+
+class RepositoryAuditColumnsForPostgresDialect(TestCase):
+    def setUp(self):
+        self.mgr = _PostgresSessionManagerStub()
+        self.repo = Repository(_WidgetDto, self.mgr)
+
+    def test_insert_uses_native_uuid_tenant_and_create_user_id(self):
+        widget = _WidgetDto()
+
+        self.repo.insert(widget)
+
+        # Branch on line 40: TenantId becomes a UUID instance, not a str.
+        self.assertIsInstance(widget.TenantId, uuid.UUID)
+        # Branch on line 47: CreateUserId is also a native UUID.
+        self.assertIsInstance(widget.CreateUserId, uuid.UUID)
+        self.mgr.session.add.assert_called_once_with(widget)
+
+    def test_update_uses_native_uuid_update_user_id(self):
+        widget = _WidgetDto()
+
+        self.repo.update(widget)
+
+        # Branch on line 55.
+        self.assertIsInstance(widget.UpdateUserId, uuid.UUID)
+
+    def test_delete_uses_native_uuid_gc_rec_id_and_update_user_id(self):
+        widget = _WidgetDto()
+
+        self.repo.delete(widget)
+
+        # Branches on lines 66-67.
+        self.assertIsInstance(widget.GcRecId, uuid.UUID)
+        self.assertIsInstance(widget.UpdateUserId, uuid.UUID)

--- a/tests/unittests/data/test_repository_provider.py
+++ b/tests/unittests/data/test_repository_provider.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``pdip.data.repository.RepositoryProvider``.
+
+The ``basic_app_with_cqrs`` suite exercises ``get`` / ``create`` /
+``commit`` end-to-end through a live ``Pdi`` container; these tests
+pin down the branches that path doesn't reach without booting
+``Pdi``: the ``query`` pass-through, ``rollback``, ``reconnect``,
+and the ``None``-manager fast-paths.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from pdip.data.repository.repository_provider import RepositoryProvider
+
+
+@dataclass
+class _DbConfigStub:
+    type: Optional[str] = None
+    connection_string: str = ""
+
+
+class RepositoryProviderDelegatesToSessionManager(TestCase):
+    def setUp(self):
+        # Arrange — a mock session manager lets us assert call
+        # propagation without a real database.
+        self.mgr = MagicMock()
+        self.provider = RepositoryProvider(
+            database_config=_DbConfigStub(),
+            database_session_manager=self.mgr,
+        )
+
+    def test_query_returns_session_query_for_entities(self):
+        sentinel_query = object()
+        self.mgr.session.query.return_value = sentinel_query
+
+        result = self.provider.query("a", "b", filter_by="x")
+
+        self.assertIs(result, sentinel_query)
+        self.mgr.session.query.assert_called_once_with("a", "b", filter_by="x")
+
+    def test_commit_delegates_to_session_manager(self):
+        self.provider.commit()
+
+        self.mgr.commit.assert_called_once_with()
+
+    def test_rollback_delegates_to_session_manager(self):
+        self.provider.rollback()
+
+        self.mgr.rollback.assert_called_once_with()
+
+    def test_reconnect_closes_and_reopens_session_manager(self):
+        self.provider.reconnect()
+
+        self.mgr.close.assert_called_once_with()
+        self.mgr.connect.assert_called_once_with()
+
+    def test_close_delegates_to_session_manager(self):
+        self.provider.close()
+
+        self.mgr.close.assert_called_once_with()
+
+
+class RepositoryProviderIsSafeWhenManagerIsNone(TestCase):
+    """Every mutating method guards on ``is not None`` before
+    delegating; those False branches must be a no-op rather than a
+    crash. This pins down lines 43-44, 47-48, 51-53, 56-57 ``False``
+    branches."""
+
+    def setUp(self):
+        self.provider = RepositoryProvider(
+            database_config=_DbConfigStub(),
+            database_session_manager=None,
+        )
+
+    def test_commit_is_noop_when_manager_absent(self):
+        # Contract: the method returns None (no raise, no side effect).
+        self.assertIsNone(self.provider.commit())
+        self.assertIsNone(self.provider.database_session_manager)
+
+    def test_rollback_is_noop_when_manager_absent(self):
+        self.assertIsNone(self.provider.rollback())
+        self.assertIsNone(self.provider.database_session_manager)
+
+    def test_reconnect_is_noop_when_manager_absent(self):
+        self.assertIsNone(self.provider.reconnect())
+        self.assertIsNone(self.provider.database_session_manager)
+
+    def test_close_is_noop_when_manager_absent(self):
+        self.assertIsNone(self.provider.close())
+        # Contract: manager is still None (nothing was created).
+        self.assertIsNone(self.provider.database_session_manager)

--- a/tests/unittests/dependency/test_api_provider.py
+++ b/tests/unittests/dependency/test_api_provider.py
@@ -1,0 +1,130 @@
+"""Unit tests for ``pdip.dependency.provider.api.api_provider.ApiProvider``.
+
+``ApiProvider`` wires Flask + flask_restx + flask_injector together
+for a full ``Pdi`` boot. The ``basic_app*`` suites exercise the
+happy path end-to-end via ``Pdi()``; these tests pin down the
+branches those suites don't hit without booting the container —
+the ``__del__`` path and the explicit ``base_url``/``doc_url``
+branches plus the ``home_redirect`` route itself.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from flask import Flask
+from injector import Injector
+
+from pdip.configuration.models.api import ApiConfig
+from pdip.configuration.models.application import ApplicationConfig
+from pdip.dependency.provider.api.api_provider import ApiProvider
+
+
+def _api_config(base_url=None, doc_url=None, version="1.0"):
+    return ApiConfig(
+        base_url=base_url,
+        doc_url=doc_url,
+        is_debug=False,
+        version=version,
+        port=None,
+        origins=None,
+        authorizations=None,
+        security=None,
+    )
+
+
+def _application_config(name="test-app"):
+    return ApplicationConfig(
+        root_directory="/tmp",
+        name=name,
+        environment="test",
+        hostname=None,
+        secret_key=None,
+    )
+
+
+class ApiProviderInitializeFlaskUsesConfiguredUrls(TestCase):
+    def test_explicit_base_url_and_doc_url_are_applied(self):
+        # Arrange — both base_url and doc_url explicitly set so the
+        # ``if ...is not None`` branches for each take effect.
+        provider = ApiProvider(
+            modules=[],
+            application_config=_application_config(),
+            api_config=_api_config(base_url="/root", doc_url="/docs"),
+            injector=Injector(),
+        )
+
+        # Act
+        provider.initialize_flask()
+
+        # Assert — the Flask app now has the ``/root`` rule installed
+        # by ``@self.app.route(base_url)`` and the redirect returns 302
+        # to ``/docs``.
+        rules = {r.rule for r in provider.app.url_map.iter_rules()}
+        self.assertIn("/root", rules)
+
+        with provider.app.test_client() as client:
+            response = client.get("/root")
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/docs", response.headers["Location"])
+
+
+class ApiProviderInitializeFlaskUsesDefaultsWhenConfigIsBlank(TestCase):
+    def test_defaults_base_url_and_doc_url_when_config_none(self):
+        provider = ApiProvider(
+            modules=[],
+            application_config=_application_config(),
+            api_config=_api_config(),
+            injector=Injector(),
+        )
+
+        provider.initialize_flask()
+
+        rules = {r.rule for r in provider.app.url_map.iter_rules()}
+        # Default base_url is '/'.
+        self.assertIn("/", rules)
+
+        with provider.app.test_client() as client:
+            response = client.get("/")
+            self.assertEqual(response.status_code, 302)
+            # Default doc_url.
+            self.assertIn("/documentation", response.headers["Location"])
+
+
+class ApiProviderDelReleasesOwnedResources(TestCase):
+    def test_del_deletes_api_app_and_logger_attributes(self):
+        # Arrange — build a provider but swap app/api/logger for
+        # plain sentinels we can observe being released.
+        provider = ApiProvider(
+            modules=[],
+            application_config=_application_config(),
+            api_config=_api_config(),
+            injector=Injector(),
+        )
+        provider.app = MagicMock(spec=Flask)
+        provider.api = MagicMock()
+        # logger is already set in __init__.
+        self.assertTrue(hasattr(provider, "logger"))
+
+        # Act
+        provider.__del__()
+
+        # Assert
+        self.assertFalse(hasattr(provider, "api"))
+        self.assertFalse(hasattr(provider, "app"))
+        self.assertFalse(hasattr(provider, "logger"))
+
+    def test_del_is_safe_when_logger_already_released(self):
+        # Covers the ``if hasattr(self, 'logger')`` False branch.
+        provider = ApiProvider(
+            modules=[],
+            application_config=_application_config(),
+            api_config=_api_config(),
+            injector=Injector(),
+        )
+        provider.app = MagicMock(spec=Flask)
+        provider.api = MagicMock()
+        del provider.logger
+
+        provider.__del__()
+
+        self.assertFalse(hasattr(provider, "logger"))

--- a/tests/unittests/json/test_date_time_parser.py
+++ b/tests/unittests/json/test_date_time_parser.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``pdip.json.parsers.date_time_parser.date_time_parser``.
+
+``date_time_parser`` is the object_hook used by ``JsonConvert`` to
+revive ISO-8601 timestamps back into ``datetime`` instances. These
+tests pin down the two recognised shapes (``T``-separated and
+``space``-separated) plus the pass-through for non-matching values.
+"""
+
+from datetime import datetime
+from unittest import TestCase
+
+from pdip.json.parsers.date_time_parser import date_time_parser
+
+
+class DateTimeParserRevivesIsoFormats(TestCase):
+    def test_t_separated_string_is_converted_to_datetime(self):
+        dct = {"at": "2026-04-24T12:30:45.123456"}
+
+        result = date_time_parser(dct)
+
+        self.assertIsInstance(result["at"], datetime)
+        self.assertEqual(
+            result["at"],
+            datetime(2026, 4, 24, 12, 30, 45, 123456),
+        )
+
+    def test_space_separated_string_is_converted_to_datetime(self):
+        dct = {"at": "2026-04-24 12:30:45.123456"}
+
+        result = date_time_parser(dct)
+
+        self.assertIsInstance(result["at"], datetime)
+        self.assertEqual(
+            result["at"],
+            datetime(2026, 4, 24, 12, 30, 45, 123456),
+        )
+
+    def test_non_matching_string_is_left_alone(self):
+        dct = {"greeting": "hello"}
+
+        result = date_time_parser(dct)
+
+        self.assertEqual(result["greeting"], "hello")
+
+    def test_non_string_values_are_left_alone(self):
+        dct = {"n": 42, "flag": True}
+
+        result = date_time_parser(dct)
+
+        self.assertEqual(result["n"], 42)
+        self.assertEqual(result["flag"], True)
+
+    def test_returns_same_dict_object(self):
+        # The parser mutates and returns the same dict — not a copy.
+        dct = {"at": "2026-04-24T12:30:45.000000"}
+
+        result = date_time_parser(dct)
+
+        self.assertIs(result, dct)

--- a/tests/unittests/logging/test_console_logger.py
+++ b/tests/unittests/logging/test_console_logger.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``pdip.logging.loggers.console.console_logger.ConsoleLogger``.
+
+The ``basic_app*`` suites exercise ``info``/``debug`` indirectly. This
+module pins down the branches those suites don't reach: ``exception``
+with/without an explicit message, plus ``critical``, ``fatal``, and
+``error`` — each of which must delegate straight to the underlying
+``logging.Logger``.
+
+Per ADR-0026 A.1 every test asserts concrete behaviour.
+"""
+
+import logging
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pdip.logging.loggers.console.console_logger import ConsoleLogger
+
+
+class ConsoleLoggerExceptionIncludesTraceback(TestCase):
+    def setUp(self):
+        # Arrange — fresh instance with a stubbed underlying logger so
+        # we can assert the exact call made.
+        self.console_logger = ConsoleLogger()
+        self.console_logger.logger = MagicMock(spec=logging.Logger)
+
+    def test_exception_without_message_formats_error_traceback(self):
+        err = RuntimeError("boom")
+
+        self.console_logger.exception(err)
+
+        self.console_logger.logger.error.assert_called_once()
+        logged = self.console_logger.logger.error.call_args.args[0]
+        self.assertIn("Error:", logged)
+        self.assertIn("boom", logged)
+
+    def test_exception_with_message_prefixes_caller_message(self):
+        err = ValueError("bad-value")
+
+        self.console_logger.exception(err, message="context: ")
+
+        logged = self.console_logger.logger.error.call_args.args[0]
+        self.assertTrue(logged.startswith("context: "))
+        self.assertIn("bad-value", logged)
+
+
+class ConsoleLoggerDelegatesLevelMethodsToLogger(TestCase):
+    def setUp(self):
+        self.console_logger = ConsoleLogger()
+        self.console_logger.logger = MagicMock(spec=logging.Logger)
+
+    def test_critical_delegates_to_logger_critical(self):
+        self.console_logger.critical("crit")
+        self.console_logger.logger.critical.assert_called_once_with("crit")
+
+    def test_fatal_delegates_to_logger_fatal(self):
+        self.console_logger.fatal("fatal-msg")
+        self.console_logger.logger.fatal.assert_called_once_with("fatal-msg")
+
+    def test_error_delegates_to_logger_error(self):
+        self.console_logger.error("err")
+        self.console_logger.logger.error.assert_called_once_with("err")
+
+    def test_warning_delegates_to_logger_warning(self):
+        self.console_logger.warning("warn")
+        self.console_logger.logger.warning.assert_called_once_with("warn")
+
+
+class ConsoleLoggerLogInitIsIdempotent(TestCase):
+    def test_log_init_skips_when_handlers_already_present(self):
+        # Arrange — first construction installs a handler on the
+        # shared 'pdip.console_logger' logger; a second construction
+        # must keep the same handler count (the ``if not
+        # self.logger.handlers`` guard).
+        first = ConsoleLogger()
+        handler_count_after_first = len(first.logger.handlers)
+
+        # Act
+        second = ConsoleLogger()
+
+        # Assert
+        self.assertEqual(
+            len(second.logger.handlers), handler_count_after_first
+        )
+
+
+class ConsoleLoggerDestructorRemovesHandler(TestCase):
+    def test_del_removes_handler_from_underlying_logger(self):
+        # Arrange — isolate with a brand-new logger so the shared
+        # module-level one doesn't leak handlers between tests.
+        console_logger = ConsoleLogger()
+        console_logger.logger = MagicMock(spec=logging.Logger)
+        handler_sentinel = object()
+        console_logger.console_handler = handler_sentinel
+
+        # Act
+        console_logger.__del__()
+
+        # Assert
+        console_logger.logger.removeHandler.assert_called_once_with(
+            handler_sentinel
+        )

--- a/tests/unittests/logging/test_file_logger.py
+++ b/tests/unittests/logging/test_file_logger.py
@@ -1,13 +1,19 @@
+"""Unit tests for ``pdip.logging.loggers.file.file_logger.FileLogger``.
+
+The FileLogger contract is that every level method is callable
+without raising. Assert it explicitly per ADR-0026 A.1 rather than
+relying on the absence of an exception. These tests also pin down
+the ``exception`` formatting branches and the destructor.
+"""
+
+import logging
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from pdip.logging.loggers.file import FileLogger
 
 
 class FileLoggerAcceptsEveryLevel(TestCase):
-    """The FileLogger contract is that every level method is callable
-    without raising. Assert it explicitly per ADR-0026 A.1 rather than
-    relying on the absence of an exception."""
-
     def test_each_level_returns_none_and_does_not_raise(self):
         file_logger = FileLogger()
         for level, message in [
@@ -18,3 +24,56 @@ class FileLoggerAcceptsEveryLevel(TestCase):
             ("fatal", "fatal"),
         ]:
             self.assertIsNone(getattr(file_logger, level)(message))
+
+
+class FileLoggerExceptionIncludesTraceback(TestCase):
+    def setUp(self):
+        self.file_logger = FileLogger()
+        self.file_logger.logger = MagicMock(spec=logging.Logger)
+
+    def test_exception_without_message_formats_error_traceback(self):
+        err = RuntimeError("boom")
+
+        self.file_logger.exception(err)
+
+        self.file_logger.logger.error.assert_called_once()
+        logged = self.file_logger.logger.error.call_args.args[0]
+        self.assertIn("Error:", logged)
+        self.assertIn("boom", logged)
+
+    def test_exception_with_message_prefixes_caller_message(self):
+        err = ValueError("bad-value")
+
+        self.file_logger.exception(err, message="context: ")
+
+        logged = self.file_logger.logger.error.call_args.args[0]
+        self.assertTrue(logged.startswith("context: "))
+        self.assertIn("bad-value", logged)
+
+
+class FileLoggerDelegatesLevelMethodsToLogger(TestCase):
+    def setUp(self):
+        self.file_logger = FileLogger()
+        self.file_logger.logger = MagicMock(spec=logging.Logger)
+
+    def test_critical_delegates_to_logger_critical(self):
+        self.file_logger.critical("crit")
+        self.file_logger.logger.critical.assert_called_once_with("crit")
+
+    def test_log_delegates_level_and_message(self):
+        self.file_logger.log(20, "info-line")
+        self.file_logger.logger.log.assert_called_once_with(20, "info-line")
+
+
+class FileLoggerDestructorRemovesHandler(TestCase):
+    def test_del_removes_handler_from_underlying_logger(self):
+        file_logger = FileLogger()
+        file_logger.logger = MagicMock(spec=logging.Logger)
+        handler_sentinel = object()
+        file_logger.file_handler = handler_sentinel
+
+        file_logger.__del__()
+
+        file_logger.logger.removeHandler.assert_called_once_with(
+            handler_sentinel
+        )


### PR DESCRIPTION
## Summary

Closes coverage gaps on **logging / json / api / data** with **49 new behavioural tests** across 6 new files + 3 extended files. 8 production modules reach **100 %**.

## Coverage delta

| Module | Before | After | Tests added |
|---|---|---|---|
| `pdip/logging/loggers/console/console_logger.py` | 82 % | **100 %** | 7 (new file) |
| `pdip/logging/loggers/file/file_logger.py` | 84 % | **100 %** | 5 (extended) |
| `pdip/json/parsers/date_time_parser.py` | 27 % | **100 %** | 5 (new file) |
| `pdip/dependency/provider/api/api_provider.py` | 90 % | **100 %** | 4 (new file) |
| `pdip/api/base/controller_base.py` | 90 % | **100 %** | 10 (new file) |
| `pdip/api/base/endpoint_base.py` | 94 % | **100 %** | 6 (new file) |
| `pdip/data/repository/repository.py` | 90 % | **100 %** | 3 (extended) |
| `pdip/data/repository/repository_provider.py` | 87 % | **100 %** | 9 (new file) |

## Pragma added (one, with an inline reason per ADR-0027 §5)

- `pdip/api/base/endpoint_base.py:42` — `input_type_names` calls `dict_keys.remove("return")`, which always raises `AttributeError`. The method is not called anywhere in the codebase. Marked:
  ```python
  def input_type_names(self):  # pragma: no cover — unused dead path; dict_keys has no remove()
  ```

## Gates

- Full suite: **559/559** tests pass.
- `coverage report --fail-under=95`: passes (**97 %** overall; target modules all 100 %).
- `quality_guard.test_conventions`: **6/6** rules pass (A.1 assertions, A.2 tautology, ADR-0027 §5 pragma-has-reason, D.1 sleeps, F.1 unittest-only, F.2 star imports).
- `diff-cover --fail-under=100`: trivially satisfied — the only `pdip/` source change in this PR is a pragma comment; all other diff is tests.

## Files touched

- Source: `pdip/api/base/endpoint_base.py` (pragma only).
- Tests: 6 new files + 3 extended files as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_