### PR TITLE
test(coverage): close final 59-line gap to reach 100%

### DIFF
--- a/pdip/api/app/flask_app_wrapper.py
+++ b/pdip/api/app/flask_app_wrapper.py
@@ -44,7 +44,7 @@ class FlaskAppWrapper(ISingleton):
         self.app.after_request(self.request_handler.after_request)
 
     def run(self):
-        self.app.run(debug=self.api_config.is_debug, host='0.0.0.0', port=self.api_config.port)
+        self.app.run(debug=self.api_config.is_debug, host='0.0.0.0', port=self.api_config.port)  # pragma: no cover — starts a blocking Flask dev server; exercised only in ``pdip`` main()
 
     def test_client(self):
         return self.app.test_client()

--- a/pdip/api/base/endpoint_wrapper.py
+++ b/pdip/api/base/endpoint_wrapper.py
@@ -83,9 +83,9 @@ class EndpointWrapper:
                         field = self.field_resolver(instance.__class__, key)
                         specified_value = fields.List(field, description=f'')
 
-            elif self.type_checker.is_base_generic(value):
+            elif self.type_checker.is_base_generic(value):  # pragma: no cover — every is_base_generic value also satisfies is_generic above, so this elif is unreachable today; kept as a documented TODO for future widening
                 # TODO:Base generic class
-                print('value type should be a structure of', value.__args__[0])
+                print('value type should be a structure of', value.__args__[0])  # pragma: no cover — see preceding elif; dead until the generic branch narrows
             elif self.type_checker.is_class(value):
                 instance = value()
                 nested_annotations = self.get_annotations(instance)

--- a/pdip/api/converter/request_converter.py
+++ b/pdip/api/converter/request_converter.py
@@ -71,9 +71,9 @@ class RequestConverter(object):
                             nested_annotations = self.get_annotations(instance)
                             if nested_annotations is not None:
                                 self.register_subclasses(nested_annotations)
-                    elif generic_type_checker.is_base_generic(value):
+                    elif generic_type_checker.is_base_generic(value):  # pragma: no cover — every is_base_generic value also satisfies is_generic above, so this elif is unreachable today
                         # TODO:Base generic class
-                        print('value type should be a structure of', value.__args__[0])
+                        print('value type should be a structure of', value.__args__[0])  # pragma: no cover — see preceding elif; dead until the generic branch narrows
                     elif inspect.isclass(value):
                         if issubclass(value, enum.Enum):
                             pass

--- a/pdip/api/specifications/paging_specification.py
+++ b/pdip/api/specifications/paging_specification.py
@@ -26,6 +26,6 @@ class PagingSpecification(IScoped):
         else:
             page_number = paging_parameter.PageNumber
         offset = (page_number - 1) * page_size
-        if offset is None or offset < self.default_offset:
-            offset = self.default_offset
+        if offset is None or offset < self.default_offset:  # pragma: no cover — offset is always (>=1 - 1) * (>=5) so >= 0; clamp is defensive only
+            offset = self.default_offset  # pragma: no cover — same defensive clamp as the guard above
         return page_size, offset

--- a/pdip/json/base/base_converter.py
+++ b/pdip/json/base/base_converter.py
@@ -88,9 +88,9 @@ class BaseConverter(object):
                             nested_annotations = self.get_annotations(instance)
                             if nested_annotations is not None:
                                 self.register_subclasses(nested_annotations)
-                    elif self.type_checker.is_base_generic(value):
+                    elif self.type_checker.is_base_generic(value):  # pragma: no cover — every is_base_generic value also satisfies is_generic above, so this elif is unreachable today
                         # TODO:Base generic class
-                        print('value type should be a structure of', value.__args__[0])
+                        print('value type should be a structure of', value.__args__[0])  # pragma: no cover — see preceding elif; dead until the generic branch narrows
                     elif self.type_checker.is_class(value):
                         self.register(value)
                         instance = value()

--- a/pdip/utils/type_checker.py
+++ b/pdip/utils/type_checker.py
@@ -50,7 +50,7 @@ class TypeChecker(ITypeChecker):
                 return False
             variadic = getattr(typing, "_VariadicGenericAlias", None)
             if variadic is not None and isinstance(class_type, variadic):
-                return True
+                return True  # pragma: no cover — typing._VariadicGenericAlias was removed in Python 3.9+; branch is defensive on modern runtimes
             return len(class_type.__parameters__) > 0
         if isinstance(class_type, typing._SpecialForm):
             return class_type._name in {'ClassVar', 'Union', 'Optional'}

--- a/tests/unittests/api/converter/test_request_converter.py
+++ b/tests/unittests/api/converter/test_request_converter.py
@@ -72,6 +72,44 @@ class _Nested:
         self.leaf = leaf
 
 
+class _AnnotatedLeaf:
+    """A class-level-annotated class whose ``get_annotations`` returns
+    a non-empty dict — used to drive the recursive ``register_subclasses``
+    call inside the generic-list branch."""
+
+    value: int = 0
+
+    def __init__(self, value: int = 0):
+        self.value = value
+
+
+class _ListOfAnnotatedLeaf:
+    items: List[_AnnotatedLeaf]
+
+    def __init__(self, items=None):
+        self.items = items or []
+
+
+class _AnnotatedWrapper:
+    """Plain class whose nested class has class-level annotations —
+    exercises the recursive call in the non-generic class branch."""
+
+    inner: _AnnotatedLeaf
+
+    def __init__(self, inner=None):
+        self.inner = inner or _AnnotatedLeaf()
+
+
+class _HasUnknownTypeAnnotation:
+    # Annotating a field with a non-class, non-generic value (e.g. an
+    # integer literal) falls through every branch and lands on the
+    # final ``print('Type not know', value)``.
+    value: 42  # type: ignore[valid-type]
+
+    def __init__(self, value=None):
+        self.value = value
+
+
 class RequestConverterRegistersClasses(TestCase):
     def test_register_stores_frozenset_of_attr_names(self):
         rc = RequestConverter()
@@ -120,6 +158,38 @@ class RequestConverterRegistersClasses(TestCase):
         # register — the non-generic class branch.
         self.assertIs(rc.mappings[frozenset({"leaf"})], _Nested)
         self.assertIs(rc.mappings[frozenset({"value"})], _Leaf)
+
+    def test_register_recurses_into_annotated_class_inside_generic_list(self):
+        # Exercises the ``if nested_annotations is not None: register_subclasses(...)``
+        # recursion inside the generic-list branch: the element class
+        # has class-level annotations that must be walked.
+        rc = RequestConverter(_ListOfAnnotatedLeaf)
+
+        self.assertIs(
+            rc.mappings[frozenset({"items"})], _ListOfAnnotatedLeaf
+        )
+        self.assertIs(
+            rc.mappings[frozenset({"value"})], _AnnotatedLeaf
+        )
+
+    def test_register_recurses_into_annotated_nested_non_generic_class(self):
+        # Exercises the recursive ``register_subclasses`` call inside
+        # the plain-class (non-generic) branch.
+        rc = RequestConverter(_AnnotatedWrapper)
+
+        self.assertIs(
+            rc.mappings[frozenset({"inner"})], _AnnotatedWrapper
+        )
+        self.assertIs(
+            rc.mappings[frozenset({"value"})], _AnnotatedLeaf
+        )
+
+    def test_register_falls_through_to_unknown_type_branch(self):
+        # A non-class, non-generic annotation value reaches the final
+        # ``print('Type not know', value)`` branch without crashing.
+        rc = RequestConverter(_HasUnknownTypeAnnotation)
+
+        self.assertIn(frozenset({"value"}), rc.mappings)
 
 
 class RequestConverterMapsJsonPayloads(TestCase):

--- a/tests/unittests/api/handlers/test_request_handler.py
+++ b/tests/unittests/api/handlers/test_request_handler.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``pdip.api.handlers.request_handler.RequestHandler``.
+
+``set_headers`` walks the configured origin allow-list and copies the
+request ``Origin`` onto the response when it matches. ``after_request``
+also drives the repository-provider close via the service provider.
+``flask.request`` is stubbed through a test request context so no
+real HTTP stack is involved.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+from pdip.api.handlers.request_handler import RequestHandler
+
+
+def _build_handler(origins):
+    api_config = MagicMock()
+    api_config.origins = origins
+    service_provider = MagicMock()
+    return (
+        RequestHandler(api_config=api_config, service_provider=service_provider),
+        api_config,
+        service_provider,
+    )
+
+
+class RequestHandlerSetHeadersAllowsConfiguredOrigins(TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_wildcard_origin_copies_request_origin_onto_response(self):
+        handler, _, _ = _build_handler(origins="*")
+        with self.app.test_request_context(
+            "/", headers={"Origin": "https://client.test"}
+        ):
+            response = MagicMock()
+            response.headers = {}
+
+            result = handler.set_headers(response)
+
+        self.assertEqual(
+            result.headers["Access-Control-Allow-Origin"], "https://client.test"
+        )
+        self.assertEqual(result.headers["Server"], "")
+
+    def test_explicit_origin_in_list_copies_request_origin(self):
+        handler, _, _ = _build_handler(
+            origins="https://a.test,https://b.test"
+        )
+        with self.app.test_request_context(
+            "/", headers={"Origin": "https://b.test"}
+        ):
+            response = MagicMock()
+            response.headers = {}
+
+            handler.set_headers(response)
+
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"], "https://b.test"
+        )
+
+    def test_origin_not_in_allow_list_does_not_set_cors_header(self):
+        handler, _, _ = _build_handler(origins="https://a.test")
+        with self.app.test_request_context(
+            "/", headers={"Origin": "https://c.test"}
+        ):
+            response = MagicMock()
+            response.headers = {}
+
+            handler.set_headers(response)
+
+        self.assertNotIn("Access-Control-Allow-Origin", response.headers)
+        self.assertEqual(response.headers["Server"], "")
+
+    def test_missing_origins_config_skips_header_copy(self):
+        handler, _, _ = _build_handler(origins=None)
+        with self.app.test_request_context(
+            "/", headers={"Origin": "https://any.test"}
+        ):
+            response = MagicMock()
+            response.headers = {}
+
+            handler.set_headers(response)
+
+        self.assertNotIn("Access-Control-Allow-Origin", response.headers)
+
+
+class RequestHandlerAfterRequestClosesRepository(TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_after_request_delegates_to_set_headers_and_closes_provider(self):
+        handler, _, service_provider = _build_handler(origins="*")
+        repo_provider = MagicMock(name="RepositoryProvider")
+        service_provider.get.return_value = repo_provider
+
+        with self.app.test_request_context(
+            "/", headers={"Origin": "https://client.test"}
+        ):
+            response = MagicMock()
+            response.headers = {}
+
+            result = handler.after_request(response)
+
+        self.assertIs(result, response)
+        repo_provider.close.assert_called_once()

--- a/tests/unittests/api/specifications/test_order_by_specification.py
+++ b/tests/unittests/api/specifications/test_order_by_specification.py
@@ -93,3 +93,18 @@ class OrderBySpecificationTranslatesParameters(TestCase):
 
         self.assertIsNone(result)
         module_finder.get_module.assert_not_called()
+
+    def test_parameter_missing_order_by_attribute_returns_none(self):
+        # Arrange — an object with ``Order`` but no ``OrderBy``. The
+        # dataclass always carries both so we drop to a bare namespace
+        # to trip the early-return guard.
+        spec, _ = _build_spec_with_stub_module()
+
+        class _OnlyOrder:
+            Order = "asc"
+
+        # Act
+        result = spec.specify(_OnlyOrder())
+
+        # Assert
+        self.assertIsNone(result)

--- a/tests/unittests/api/specifications/test_paging_specification.py
+++ b/tests/unittests/api/specifications/test_paging_specification.py
@@ -63,3 +63,17 @@ class PagingSpecificationNormalisesParameters(TestCase):
 
         self.assertEqual(page_size, 25)
         self.assertEqual(offset, 0)
+
+    def test_parameter_missing_page_size_attribute_returns_none_pair(self):
+        # Arrange — an object with PageNumber but no PageSize attribute
+        # at all. ``PagingParameter`` always defines both, so build a
+        # bare object to hit the early-return guard.
+        class _OnlyPageNumber:
+            PageNumber = 1
+
+        # Act
+        page_size, offset = self.spec.specify(_OnlyPageNumber())
+
+        # Assert
+        self.assertIsNone(page_size)
+        self.assertIsNone(offset)

--- a/tests/unittests/base/test_pdi.py
+++ b/tests/unittests/base/test_pdi.py
@@ -83,3 +83,32 @@ class PdiAutoDiscoversRootDirectory(TestCase):
             self.assertTrue(os.path.isdir(pdi.root_directory))
         finally:
             pdi.cleanup()
+
+
+class PdiSetSecretKeyDelegatesToConfigManager(TestCase):
+    def setUp(self):
+        DependencyContainer.cleanup()
+        self._tmp = tempfile.mkdtemp(prefix="pdip-test-")
+        self.pdi = Pdi(root_directory=self._tmp)
+
+    def tearDown(self):
+        self.pdi.cleanup()
+        try:
+            os.rmdir(self._tmp)
+        except OSError:
+            pass
+
+    def test_set_secret_key_forwards_to_application_config(self):
+        # Arrange — patch the config manager's ``set`` to observe the call.
+        with patch.object(
+            DependencyContainer.Instance.config_manager, "set"
+        ) as set_mock:
+            # Act
+            self.pdi.set_secret_key("s3cret")
+
+        # Assert — the call goes through for ``ApplicationConfig``'s
+        # ``secret_key`` attribute.
+        self.assertEqual(set_mock.call_count, 1)
+        args, _ = set_mock.call_args
+        self.assertEqual(args[1], "secret_key")
+        self.assertEqual(args[2], "s3cret")

--- a/tests/unittests/cqrs/generator/test_generator_base.py
+++ b/tests/unittests/cqrs/generator/test_generator_base.py
@@ -1,0 +1,25 @@
+"""Unit tests for the abstract ``pdip.cqrs.generator.domain.generator.Generator``.
+
+``Generator`` is a single-method ABC whose ``generate`` body is
+``pass``. Exercise the stub through a concrete subclass to pin the
+base signature.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from pdip.cqrs.generator.domain.generator import Generator
+
+
+class _ConcreteGenerator(Generator):
+    def generate(self, generate_config):
+        return super().generate(generate_config)
+
+
+class GeneratorBaseStub(TestCase):
+    def test_super_generate_returns_none(self):
+        subject = _ConcreteGenerator()
+
+        result = subject.generate(generate_config=MagicMock())
+
+        self.assertIsNone(result)

--- a/tests/unittests/cqrs/test_base_contracts.py
+++ b/tests/unittests/cqrs/test_base_contracts.py
@@ -1,0 +1,61 @@
+"""Unit tests for the CQRS base-class stubs.
+
+These module-level contract classes (``CommandQueryBase``,
+``CommandQueryHandlerBase``, ``ICommandHandler``, ``IQueryHandler``)
+expose ``__init__`` / ``handle`` no-ops that exist to anchor a shared
+signature for concrete implementations. Each stub body is a single
+``pass`` — exercise it so the contract lines are covered and a
+regression to the signatures lands here.
+"""
+
+from unittest import TestCase
+
+from pdip.cqrs.command_query_base import CommandQueryBase
+from pdip.cqrs.command_query_handler_base import CommandQueryHandlerBase
+from pdip.cqrs.icommand_handler import ICommandHandler
+from pdip.cqrs.iquery_handler import IQueryHandler
+
+
+class CommandQueryBaseStubConstructs(TestCase):
+    def test_instantiation_does_not_raise(self):
+        # Arrange + Act
+        instance = CommandQueryBase()
+
+        # Assert
+        self.assertIsInstance(instance, CommandQueryBase)
+
+
+class CommandQueryHandlerBaseStubs(TestCase):
+    def test_init_stub_returns_instance(self):
+        instance = CommandQueryHandlerBase()
+
+        self.assertIsInstance(instance, CommandQueryHandlerBase)
+
+    def test_handle_stub_returns_none(self):
+        instance = CommandQueryHandlerBase()
+
+        self.assertIsNone(instance.handle(query=object()))
+
+
+class ICommandHandlerStubs(TestCase):
+    def test_init_stub_returns_instance(self):
+        instance = ICommandHandler()
+
+        self.assertIsInstance(instance, ICommandHandler)
+
+    def test_handle_stub_returns_none(self):
+        instance = ICommandHandler()
+
+        self.assertIsNone(instance.handle(query=object()))
+
+
+class IQueryHandlerStubs(TestCase):
+    def test_init_stub_returns_instance(self):
+        instance = IQueryHandler()
+
+        self.assertIsInstance(instance, IQueryHandler)
+
+    def test_handle_stub_returns_none(self):
+        instance = IQueryHandler()
+
+        self.assertIsNone(instance.handle(query=object()))

--- a/tests/unittests/data/domain/test_guid_type.py
+++ b/tests/unittests/data/domain/test_guid_type.py
@@ -1,0 +1,114 @@
+"""Unit tests for ``pdip.data.domain.types.GUID``.
+
+``GUID`` is a ``TypeDecorator`` that normalises UUID handling across
+PostgreSQL (native ``UUID``) and everything else (``CHAR(32)`` hex).
+Each branch is exercised with a ``MagicMock`` dialect so no real
+database engine is needed.
+"""
+
+import uuid
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from sqlalchemy import UUID as SA_UUID
+from sqlalchemy.types import CHAR
+
+from pdip.data.domain.types.GUID import GUID
+
+
+class GUIDLoadDialectImplBranches(TestCase):
+    def test_postgresql_dialect_descends_to_native_uuid(self):
+        # Arrange
+        subject = GUID()
+        dialect = MagicMock(name="postgres_dialect")
+        dialect.name = "postgresql"
+        dialect.type_descriptor.return_value = "native-uuid-descriptor"
+
+        # Act
+        result = subject.load_dialect_impl(dialect)
+
+        # Assert — the returned descriptor comes from the dialect and
+        # the argument to ``type_descriptor`` is a ``sqlalchemy.UUID``.
+        self.assertEqual(result, "native-uuid-descriptor")
+        (arg,), _ = dialect.type_descriptor.call_args
+        self.assertIsInstance(arg, SA_UUID)
+
+    def test_non_postgresql_dialect_falls_back_to_char_32(self):
+        # Arrange
+        subject = GUID()
+        dialect = MagicMock(name="sqlite_dialect")
+        dialect.name = "sqlite"
+        dialect.type_descriptor.return_value = "char-descriptor"
+
+        # Act
+        result = subject.load_dialect_impl(dialect)
+
+        # Assert
+        self.assertEqual(result, "char-descriptor")
+        (arg,), _ = dialect.type_descriptor.call_args
+        self.assertIsInstance(arg, CHAR)
+        self.assertEqual(arg.length, 32)
+
+
+class GUIDProcessBindParamBranches(TestCase):
+    def test_none_value_is_passed_through(self):
+        subject = GUID()
+        dialect = MagicMock()
+        dialect.name = "sqlite"
+
+        self.assertIsNone(subject.process_bind_param(None, dialect))
+
+    def test_postgresql_returns_stringified_value(self):
+        subject = GUID()
+        dialect = MagicMock()
+        dialect.name = "postgresql"
+        uid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+        result = subject.process_bind_param(uid, dialect)
+
+        self.assertEqual(result, str(uid))
+
+    def test_non_postgresql_string_input_is_hex_formatted(self):
+        subject = GUID()
+        dialect = MagicMock()
+        dialect.name = "sqlite"
+
+        result = subject.process_bind_param(
+            "12345678-1234-5678-1234-567812345678", dialect
+        )
+
+        self.assertEqual(result, "12345678123456781234567812345678")
+
+    def test_non_postgresql_uuid_input_is_hex_formatted(self):
+        subject = GUID()
+        dialect = MagicMock()
+        dialect.name = "sqlite"
+        uid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+        result = subject.process_bind_param(uid, dialect)
+
+        self.assertEqual(result, "12345678123456781234567812345678")
+
+
+class GUIDProcessResultValueBranches(TestCase):
+    def test_none_value_returns_none(self):
+        subject = GUID()
+
+        self.assertIsNone(subject.process_result_value(None, MagicMock()))
+
+    def test_string_value_is_parsed_to_uuid(self):
+        subject = GUID()
+        raw = "12345678123456781234567812345678"
+
+        result = subject.process_result_value(raw, MagicMock())
+
+        self.assertIsInstance(result, uuid.UUID)
+        self.assertEqual(result.hex, raw)
+
+    def test_uuid_value_is_passed_through(self):
+        subject = GUID()
+        uid = uuid.uuid4()
+
+        result = subject.process_result_value(uid, MagicMock())
+
+        self.assertIs(result, uid)

--- a/tests/unittests/data/seed/test_seed_base.py
+++ b/tests/unittests/data/seed/test_seed_base.py
@@ -1,0 +1,24 @@
+"""Unit tests for the abstract ``pdip.data.seed.seed.Seed``.
+
+``Seed`` declares a single ``@abstractmethod`` ``seed`` whose body is
+``pass``. Exercise it through a concrete subclass so the stub body
+executes.
+"""
+
+from unittest import TestCase
+
+from pdip.data.seed.seed import Seed
+
+
+class _ConcreteSeed(Seed):
+    def seed(self):
+        return super().seed()
+
+
+class SeedAbstractStubReturnsNone(TestCase):
+    def test_super_seed_returns_none(self):
+        subject = _ConcreteSeed()
+
+        result = subject.seed()
+
+        self.assertIsNone(result)

--- a/tests/unittests/data/test_database_session_manager.py
+++ b/tests/unittests/data/test_database_session_manager.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``pdip.data.base.database_session_manager.DatabaseSessionManager``.
+
+The session manager owns engine/session construction. These tests
+exercise two connect() branches that the integration suites do not
+reach:
+
+* connection-string auto-derivation when the config leaves it blank,
+* the non-SQLITE engine-construction branch (uses ``NullPool``).
+
+``sqlalchemy.create_engine`` is mocked at the module boundary so no
+real database engine is started.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pdip.configuration.models.database import DatabaseConfig
+from pdip.data.base import database_session_manager as dsm_module
+
+
+class DatabaseSessionManagerConnectBranches(TestCase):
+    def test_blank_connection_string_is_auto_derived_from_config(self):
+        # Arrange
+        config = DatabaseConfig(
+            type="SQLITE",
+            connection_string="",
+            host="auto.db",
+        )
+
+        with patch.object(dsm_module, "create_engine") as create_engine, \
+             patch.object(dsm_module, "sessionmaker") as sessionmaker:
+            create_engine.return_value = MagicMock(name="engine")
+            sessionmaker.return_value = MagicMock(
+                return_value=MagicMock(name="session")
+            )
+
+            # Act
+            manager = dsm_module.DatabaseSessionManager(database_config=config)
+
+        # Assert — the blank string was replaced and then passed to
+        # create_engine as the first positional argument.
+        self.assertNotEqual(manager.database_config.connection_string, "")
+        (dsn_arg,), _ = create_engine.call_args
+        self.assertEqual(dsn_arg, manager.database_config.connection_string)
+
+    def test_non_sqlite_engine_uses_null_pool_and_application_name(self):
+        # Arrange
+        config = DatabaseConfig(
+            type="POSTGRESQL",
+            connection_string="postgresql://user:pass@db:5432/app",
+            application_name="pdip-tests",
+        )
+
+        with patch.object(dsm_module, "create_engine") as create_engine, \
+             patch.object(dsm_module, "sessionmaker") as sessionmaker:
+            create_engine.return_value = MagicMock(name="engine")
+            sessionmaker.return_value = MagicMock(
+                return_value=MagicMock(name="session")
+            )
+
+            # Act
+            dsm_module.DatabaseSessionManager(database_config=config)
+
+        # Assert — the non-SQLITE branch forwards NullPool + application_name.
+        _, kwargs = create_engine.call_args
+        self.assertIs(kwargs["poolclass"], dsm_module.pool.NullPool)
+        self.assertTrue(kwargs["pool_pre_ping"])
+        self.assertEqual(
+            kwargs["connect_args"], {"application_name": "pdip-tests"}
+        )

--- a/tests/unittests/dependency/test_dependency_container.py
+++ b/tests/unittests/dependency/test_dependency_container.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``pdip.dependency.container.DependencyContainer``.
+
+The container wraps a ``ServiceProvider`` on the class and exposes
+``initialize_service`` / ``cleanup`` for bootstrap. These tests cover
+the failure path of ``initialize_service`` (where a raising
+``ServiceProvider`` must trigger ``cleanup`` and re-raise) and the
+cleanup of an already-missing instance.
+"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from pdip.dependency.container import DependencyContainer
+
+
+class DependencyContainerInitializeFailurePath(TestCase):
+    def setUp(self):
+        DependencyContainer.cleanup()
+
+    def tearDown(self):
+        DependencyContainer.cleanup()
+
+    def test_service_provider_construction_failure_triggers_cleanup_and_reraises(self):
+        # Arrange — patch ``ServiceProvider`` inside the module under
+        # test so construction fails immediately.
+        with patch(
+            "pdip.dependency.container.dependency_container.ServiceProvider",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Act / Assert — the original exception is re-raised.
+            with self.assertRaises(RuntimeError) as ctx:
+                DependencyContainer.initialize_service(root_directory="/tmp")
+
+        self.assertEqual(str(ctx.exception), "boom")
+        # And ``cleanup`` ran: the Instance is None after the failure.
+        self.assertIsNone(DependencyContainer.Instance)
+
+
+class DependencyContainerCleanupIsIdempotent(TestCase):
+    def setUp(self):
+        DependencyContainer.cleanup()
+
+    def test_cleanup_with_no_instance_is_a_no_op(self):
+        # Arrange: Instance is already None after setUp.
+        self.assertIsNone(DependencyContainer.Instance)
+
+        # Act — must not raise.
+        DependencyContainer.cleanup()
+
+        # Assert — still None.
+        self.assertIsNone(DependencyContainer.Instance)

--- a/tests/unittests/integrator/connection/domain/test_authentication_type_values.py
+++ b/tests/unittests/integrator/connection/domain/test_authentication_type_values.py
@@ -1,0 +1,37 @@
+"""Unit tests for ``pdip.integrator.connection.domain.authentication.type``.
+
+``AuthenticationTypes`` is exchanged as a plain integer in persisted
+connection configuration. Pin the contract values so a member rename
+cannot accidentally renumber and break the on-disk schema.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+
+from pdip.integrator.connection.domain.authentication.type import (  # noqa: E402
+    AuthenticationTypes,
+)
+from pdip.integrator.connection.domain.authentication.type.authentication_types import (  # noqa: E402
+    AuthenticationTypes as AuthenticationTypesDirect,
+)
+
+
+class AuthenticationTypesMembersPinContractValues(TestCase):
+    def test_no_authentication_member_has_value_zero(self):
+        self.assertEqual(AuthenticationTypes.NoAuthentication.value, 0)
+
+    def test_basic_authentication_member_has_value_one(self):
+        self.assertEqual(AuthenticationTypes.BasicAuthentication.value, 1)
+
+    def test_kerberos_member_has_value_two(self):
+        self.assertEqual(AuthenticationTypes.Kerberos.value, 2)
+
+    def test_package_reexport_is_same_enum_type(self):
+        self.assertIs(AuthenticationTypes, AuthenticationTypesDirect)
+
+    def test_enum_contains_exactly_three_members(self):
+        self.assertEqual(
+            sorted(m.name for m in AuthenticationTypes),
+            ["BasicAuthentication", "Kerberos", "NoAuthentication"],
+        )

--- a/tests/unittests/integrator/connection/test_connection_adapter_contracts.py
+++ b/tests/unittests/integrator/connection/test_connection_adapter_contracts.py
@@ -1,0 +1,89 @@
+"""Unit tests for the abstract connection adapter contracts.
+
+``ConnectionSourceAdapter`` and ``ConnectionTargetAdapter`` declare
+``@abstractmethod`` stubs whose bodies are ``pass``. Hit the bodies
+via a concrete subclass that calls ``super()`` so the contract lines
+execute and regression risk on the abstract signatures is pinned.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.connection.base.connection_source_adapter import (  # noqa: E402
+    ConnectionSourceAdapter,
+)
+from pdip.integrator.connection.base.connection_target_adapter import (  # noqa: E402
+    ConnectionTargetAdapter,
+)
+
+
+class _ConcreteSourceAdapter(ConnectionSourceAdapter):
+    def get_source_data_count(self, integration):
+        return super().get_source_data_count(integration)
+
+    def get_iterator(self, integration, limit):
+        return super().get_iterator(integration, limit)
+
+    def get_source_data_with_paging(self, integration, start, end):
+        return super().get_source_data_with_paging(integration, start, end)
+
+
+class _ConcreteTargetAdapter(ConnectionTargetAdapter):
+    def clear_data(self, integration):
+        return super().clear_data(integration)
+
+    def write_data(self, integration, source_data):
+        return super().write_data(integration, source_data)
+
+    def do_target_operation(self, integration):
+        return super().do_target_operation(integration)
+
+
+class ConnectionSourceAdapterAbstractStubsReturnNone(TestCase):
+    def test_get_source_data_count_stub_returns_none(self):
+        adapter = _ConcreteSourceAdapter()
+
+        result = adapter.get_source_data_count(integration=MagicMock())
+
+        self.assertIsNone(result)
+
+    def test_get_iterator_stub_returns_none(self):
+        adapter = _ConcreteSourceAdapter()
+
+        result = adapter.get_iterator(integration=MagicMock(), limit=10)
+
+        self.assertIsNone(result)
+
+    def test_get_source_data_with_paging_stub_returns_none(self):
+        adapter = _ConcreteSourceAdapter()
+
+        result = adapter.get_source_data_with_paging(
+            integration=MagicMock(), start=0, end=5
+        )
+
+        self.assertIsNone(result)
+
+
+class ConnectionTargetAdapterAbstractStubsReturnNone(TestCase):
+    def test_clear_data_stub_returns_none(self):
+        adapter = _ConcreteTargetAdapter()
+
+        result = adapter.clear_data(integration=MagicMock())
+
+        self.assertIsNone(result)
+
+    def test_write_data_stub_returns_none(self):
+        adapter = _ConcreteTargetAdapter()
+
+        result = adapter.write_data(integration=MagicMock(), source_data=[1, 2])
+
+        self.assertIsNone(result)
+
+    def test_do_target_operation_stub_returns_none(self):
+        adapter = _ConcreteTargetAdapter()
+
+        result = adapter.do_target_operation(integration=MagicMock())
+
+        self.assertIsNone(result)

--- a/tests/unittests/integrator/event/test_integrator_event_manager_factory.py
+++ b/tests/unittests/integrator/event/test_integrator_event_manager_factory.py
@@ -10,7 +10,7 @@ Same subclass-discovery pattern as the initializer factories:
 from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
 
 from unittest import TestCase  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 from pdip.integrator.event.base.default_integrator_event_manager import (  # noqa: E402
     DefaultIntegratorEventManager,
@@ -30,10 +30,18 @@ class IntegratorEventManagerFactoryChoosesSubclass(TestCase):
         provider.get.return_value = sentinel
 
         factory = IntegratorEventManagerFactory(service_provider=provider)
-        result = factory.get()
+        # Pin the subclass list to the default entry so the
+        # ``len(subclasses) == 1`` branch runs — other tests in this
+        # process may register ad-hoc subclasses that linger.
+        with patch.object(
+            IntegratorEventManager,
+            "__subclasses__",
+            return_value=[DefaultIntegratorEventManager],
+        ):
+            result = factory.get()
 
         self.assertIs(result, sentinel)
-        provider.get.assert_called_once()
+        provider.get.assert_called_once_with(DefaultIntegratorEventManager)
 
     def test_prefers_custom_subclass_over_default(self):
         class _Custom(IntegratorEventManager):

--- a/tests/unittests/integrator/initializer/test_integrator_initializer_factory.py
+++ b/tests/unittests/integrator/initializer/test_integrator_initializer_factory.py
@@ -11,7 +11,7 @@ and resolves one via the ``ServiceProvider``. We verify:
 from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
 
 from unittest import TestCase  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 from pdip.integrator.initializer.integrator.default_integrator_initializer import (  # noqa: E402
     DefaultIntegratorInitializer,
@@ -31,13 +31,19 @@ class IntegratorInitializerFactoryChoosesSubclass(TestCase):
         provider.get.return_value = sentinel
 
         factory = IntegratorInitializerFactory(service_provider=provider)
-        # This test relies on the default being present in the subclass
-        # registry. If a custom subclass is registered elsewhere the
-        # factory would prefer it — which is covered separately below.
-        result = factory.get()
+        # Pin the subclass list to exactly one entry so the
+        # ``len(subclasses) == 1`` branch runs — other tests in this
+        # process may register ad-hoc subclasses whose weakrefs are
+        # still live.
+        with patch.object(
+            IntegratorInitializer,
+            "__subclasses__",
+            return_value=[DefaultIntegratorInitializer],
+        ):
+            result = factory.get()
 
         self.assertIs(result, sentinel)
-        provider.get.assert_called_once()
+        provider.get.assert_called_once_with(DefaultIntegratorInitializer)
 
     def test_prefers_custom_subclass_over_default(self):
         class _Custom(IntegratorInitializer):

--- a/tests/unittests/integrator/initializer/test_operation_integration_execution_initializer_factory.py
+++ b/tests/unittests/integrator/initializer/test_operation_integration_execution_initializer_factory.py
@@ -7,7 +7,7 @@ alone, custom preferred otherwise, provider is the boundary.
 from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
 
 from unittest import TestCase  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 from pdip.integrator.initializer.execution.integration.default_operation_integration_execution_initializer import (  # noqa: E402
     DefaultOperationIntegrationExecutionInitializer,
@@ -29,10 +29,20 @@ class OperationIntegrationExecutionInitializerFactoryChoosesSubclass(TestCase):
         factory = OperationIntegrationExecutionInitializerFactory(
             service_provider=provider
         )
-        result = factory.get()
+        # Pin the subclass list to the default entry so the
+        # ``len(subclasses) == 1`` branch runs — other tests in this
+        # process may register ad-hoc subclasses that linger.
+        with patch.object(
+            OperationIntegrationExecutionInitializer,
+            "__subclasses__",
+            return_value=[DefaultOperationIntegrationExecutionInitializer],
+        ):
+            result = factory.get()
 
         self.assertIs(result, sentinel)
-        provider.get.assert_called_once()
+        provider.get.assert_called_once_with(
+            DefaultOperationIntegrationExecutionInitializer
+        )
 
     def test_prefers_custom_subclass_over_default(self):
         class _Custom(OperationIntegrationExecutionInitializer):

--- a/tests/unittests/integrator/integration/sourcetotarget/test_strategy_base_contract.py
+++ b/tests/unittests/integrator/integration/sourcetotarget/test_strategy_base_contract.py
@@ -1,0 +1,42 @@
+"""Unit tests for the abstract
+``IntegrationSourceToTargetExecuteStrategy`` contract.
+
+The base class has an ``@inject`` no-op ``__init__`` and an
+``@abstractmethod`` ``execute`` whose body is ``pass``. Exercise both
+through a concrete subclass that calls ``super()``.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.integration.types.sourcetotarget.strategies.base.integration_source_to_target_execute_strategy import (  # noqa: E402
+    IntegrationSourceToTargetExecuteStrategy,
+)
+
+
+class _ConcreteStrategy(IntegrationSourceToTargetExecuteStrategy):
+    def execute(self, operation_integration, channel):
+        return super().execute(operation_integration, channel)
+
+
+class IntegrationSourceToTargetExecuteStrategyBaseContract(TestCase):
+    def test_base_init_runs_without_arguments(self):
+        # Arrange + Act
+        subject = _ConcreteStrategy()
+
+        # Assert — the concrete subclass is an instance of the ABC.
+        self.assertIsInstance(subject, IntegrationSourceToTargetExecuteStrategy)
+
+    def test_super_execute_returns_none(self):
+        # Arrange
+        subject = _ConcreteStrategy()
+
+        # Act
+        result = subject.execute(
+            operation_integration=MagicMock(), channel=MagicMock()
+        )
+
+        # Assert
+        self.assertIsNone(result)

--- a/tests/unittests/integrator/integration/test_enum_values.py
+++ b/tests/unittests/integrator/integration/test_enum_values.py
@@ -1,0 +1,38 @@
+"""Unit tests for ``pdip.integrator.integration.domain.enums``.
+
+``IntegrationTypes`` is a flat ``Enum`` whose integer values are
+exchanged on the wire (they appear in persisted operation / integration
+records). Pin the numeric contract so a rename does not silently
+renumber and corrupt downstream consumers.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+
+from pdip.integrator.integration.domain.enums import IntegrationTypes  # noqa: E402
+from pdip.integrator.integration.domain.enums.integration_types import (  # noqa: E402
+    IntegrationTypes as IntegrationTypesDirect,
+)
+
+
+class IntegrationTypesMembersPinContractValues(TestCase):
+    def test_source_member_has_value_one(self):
+        self.assertEqual(IntegrationTypes.Source.value, 1)
+
+    def test_target_member_has_value_two(self):
+        self.assertEqual(IntegrationTypes.Target.value, 2)
+
+    def test_source_to_target_member_has_value_three(self):
+        self.assertEqual(IntegrationTypes.SourceToTarget.value, 3)
+
+    def test_package_reexport_is_same_enum_type(self):
+        # The package __init__ re-exports the enum; guard against an
+        # accidental divergence between the two import paths.
+        self.assertIs(IntegrationTypes, IntegrationTypesDirect)
+
+    def test_enum_contains_exactly_three_members(self):
+        self.assertEqual(
+            sorted(m.name for m in IntegrationTypes),
+            ["Source", "SourceToTarget", "Target"],
+        )

--- a/tests/unittests/integrator/integration/test_integration_adapter_contract.py
+++ b/tests/unittests/integrator/integration/test_integration_adapter_contract.py
@@ -1,0 +1,60 @@
+"""Unit tests for the abstract ``IntegrationAdapter`` contract.
+
+``IntegrationAdapter`` declares four ``@abstractmethod`` stubs whose
+bodies are a single ``pass`` used only to document the contract for
+subclasses that choose to call ``super()``. We invoke them through a
+concrete subclass so the ``pass`` lines execute.
+"""
+
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from pdip.integrator.integration.types.base.integration_adapter import (  # noqa: E402
+    IntegrationAdapter,
+)
+
+
+class _ConcreteIntegrationAdapter(IntegrationAdapter):
+    def execute(self, operation_integration, channel):
+        return super().execute(operation_integration, channel)
+
+    def get_start_message(self, integration):
+        return super().get_start_message(integration)
+
+    def get_finish_message(self, integration, data_count):
+        return super().get_finish_message(integration, data_count)
+
+    def get_error_message(self, integration):
+        return super().get_error_message(integration)
+
+
+class IntegrationAdapterAbstractStubsReturnNone(TestCase):
+    def test_execute_stub_returns_none(self):
+        adapter = _ConcreteIntegrationAdapter()
+
+        result = adapter.execute(operation_integration=MagicMock(), channel=MagicMock())
+
+        self.assertIsNone(result)
+
+    def test_get_start_message_stub_returns_none(self):
+        adapter = _ConcreteIntegrationAdapter()
+
+        result = adapter.get_start_message(integration=MagicMock())
+
+        self.assertIsNone(result)
+
+    def test_get_finish_message_stub_returns_none(self):
+        adapter = _ConcreteIntegrationAdapter()
+
+        result = adapter.get_finish_message(integration=MagicMock(), data_count=3)
+
+        self.assertIsNone(result)
+
+    def test_get_error_message_stub_returns_none(self):
+        adapter = _ConcreteIntegrationAdapter()
+
+        result = adapter.get_error_message(integration=MagicMock())
+
+        self.assertIsNone(result)

--- a/tests/unittests/json/test_base_converter.py
+++ b/tests/unittests/json/test_base_converter.py
@@ -8,6 +8,7 @@ branch behaviour so regressions land here, not in downstream DTO flows.
 
 import json
 import uuid
+from datetime import datetime
 from typing import List
 from unittest import TestCase
 from unittest.mock import MagicMock
@@ -262,3 +263,40 @@ class BaseConverterRegisterSubclassesCoversBranches(TestCase):
 
         # Assert
         self.assertEqual(converter.mappings, before)
+
+    def test_datetime_primitive_annotation_is_skipped(self):
+        # Arrange — a class annotated with ``datetime`` hits the
+        # ``elif value == datetime: pass`` branch.
+        class _HasDatetime:
+            timestamp: datetime = None
+
+            def __init__(self, timestamp=None):
+                self.timestamp = timestamp
+
+        converter = BaseConverter()
+
+        # Act
+        converter.register(_HasDatetime)
+
+        # Assert — only the outer class registers; datetime is a
+        # primitive branch that does not recurse.
+        self.assertEqual(len(converter.mappings), 1)
+        self.assertIn(_HasDatetime, converter.mappings.values())
+
+    def test_unknown_annotation_falls_through_to_print_branch(self):
+        # Arrange — a non-class, non-generic annotation (an integer
+        # literal) triggers the final ``print('Type not know', value)``
+        # branch.
+        class _HasUnknown:
+            value: 42  # type: ignore[valid-type]
+
+            def __init__(self, value=None):
+                self.value = value
+
+        converter = BaseConverter()
+
+        # Act
+        converter.register(_HasUnknown)
+
+        # Assert
+        self.assertIn(frozenset({"value"}), converter.mappings)

--- a/tests/unittests/json/test_multiple_json_encoders.py
+++ b/tests/unittests/json/test_multiple_json_encoders.py
@@ -1,0 +1,43 @@
+"""Unit tests for ``pdip.json.encoders.mutliple_json_encoders.MultipleJsonEncoders``.
+
+The combiner walks a list of ``JSONEncoder`` subclasses and returns
+the first encoder that succeeds. When none do, it raises
+``TypeError`` naming the offending type.
+"""
+
+import json
+from datetime import datetime
+from unittest import TestCase
+
+from pdip.json.encoders.date_time_encoder import DateTimeEncoder
+from pdip.json.encoders.mutliple_json_encoders import MultipleJsonEncoders
+from pdip.json.encoders.uuid_encoder import UUIDEncoder
+
+
+class _Unserialisable:
+    """A class none of the known encoders can handle."""
+
+    pass
+
+
+class MultipleJsonEncodersRaisesWhenNoneMatch(TestCase):
+    def test_raises_type_error_for_type_no_encoder_handles(self):
+        # Arrange — combine the datetime + UUID encoders; neither
+        # handles a ``_Unserialisable`` instance.
+        encoder = MultipleJsonEncoders(DateTimeEncoder, UUIDEncoder)
+
+        # Act / Assert
+        with self.assertRaises(TypeError) as ctx:
+            json.dumps({"v": _Unserialisable()}, cls=encoder)
+
+        self.assertIn("_Unserialisable", str(ctx.exception))
+
+    def test_accepts_handled_type_via_first_encoder(self):
+        # Sanity: the combiner still serialises a datetime through
+        # the first encoder in the chain.
+        encoder = MultipleJsonEncoders(DateTimeEncoder, UUIDEncoder)
+        moment = datetime(2026, 4, 24, 10, 0, 0)
+
+        payload = json.dumps({"ts": moment}, cls=encoder)
+
+        self.assertIn(moment.isoformat(), payload)

--- a/tests/unittests/utils/test_type_checker.py
+++ b/tests/unittests/utils/test_type_checker.py
@@ -97,3 +97,11 @@ class TypeCheckerIsBaseGenericMatchesOpenGenerics(TestCase):
             TypeChecker().is_base_generic(typing.List[int]),
             False,
         )
+
+    def test_generic_origin_parameterisation_is_not_base_generic(self):
+        # ``typing.Generic[TypeVar]`` has an origin equal to
+        # ``typing.Generic`` itself — the helper must short-circuit to
+        # ``False`` (it is the bare ``Generic``, not an open generic).
+        T = typing.TypeVar("T")
+
+        self.assertFalse(TypeChecker().is_base_generic(typing.Generic[T]))


### PR DESCRIPTION
## Summary

Closes the last 59 uncovered lines to take measured coverage from **98% to 100%** (3724/3724 statements).

- 60 new behavioural tests across 13 new files (total tests: 604 → 664)
- 8 new `# pragma: no cover` lines, each with an inline reason comment (satisfying the ADR-0027 §5 machine-enforced rule)
- No production behaviour change — only assertions, pragmas, and new test files

### Pragmas added (all with inline reasons)

| File | Line | Reason |
|---|---|---|
| `pdip/api/specifications/paging_specification.py` | 29, 30 | defensive clamps unreachable under `page_number >= 1, page_size >= 5` invariants |
| `pdip/utils/type_checker.py` | 53 | `typing._VariadicGenericAlias` removed in Python 3.9+; branch defensive on modern runtimes |
| `pdip/api/app/flask_app_wrapper.py` | 47 | blocking Flask dev server — exercised only via `pdip` main() |
| `pdip/api/base/endpoint_wrapper.py` | 86, 88 | every `is_base_generic` satisfies `is_generic` above; elif unreachable today |
| `pdip/api/converter/request_converter.py` | 74, 76 | same unreachable `is_base_generic` elif |
| `pdip/json/base/base_converter.py` | 91, 93 | same unreachable `is_base_generic` elif |

### Verification

- `coverage report --fail-under=100` → exit 0, TOTAL 3724/3724 100%
- `python -m unittest tests.unittests.quality_guard.test_conventions` → 6/6 OK
- `diff-cover coverage.xml --compare-branch origin/main --fail-under=100` → exit 0

### Why this PR stays at `fail_under=95`

The floor bump (95 → 100) is a follow-up PR that also updates `.github/workflows/package-build-and-tests.yml` and the CHANGELOG. Splitting keeps this diff focused on test content.

## Test plan

- [x] `python run_tests.py` — 664/664 pass
- [x] `coverage report --fail-under=100` — green
- [x] `tests.unittests.quality_guard.test_conventions` — 6/6 green (ADR-0026 + ADR-0027 §5)
- [x] CI matrix (3.9–3.14 × Linux/macOS/Windows) must stay green

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_