### PR TITLE
fix(ci): bump coverage 7.6.12 → 7.13.5, restore XML on every cell

### DIFF
--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -40,36 +40,42 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with unittest and coverage
-        # Every matrix cell runs the suite under ``coverage`` and
-        # emits ``coverage.xml``. The ``fail_under`` floor runs only
-        # on the canonical cell (3.11 ubuntu) because coverage is a
-        # single scalar, not a per-Python-version property. See
-        # ADR-0023 §5. ``--fail-under=0`` overrides ``.coveragerc``
-        # so this shared step never fails on a non-canonical cell.
-        # ``shell: bash`` makes the step work identically on Windows
-        # (git-bash is always present on the runner) and lets the
-        # ``tee`` / ``PIPESTATUS`` pattern below capture exit codes
-        # into an uploadable log for remote debugging.
+      - name: Test with unittest and coverage (diagnostics enabled)
         shell: bash
         run: |
-          set -o pipefail
-          python --version 2>&1 | tee -a coverage-run.log
+          python -c "import sys; print('python', sys.version)" 2>&1 | tee coverage-run.log
           coverage --version 2>&1 | tee -a coverage-run.log
-          coverage run run_tests.py 2>&1 | tee -a coverage-run.log
-          echo "=== coverage run exit=$? ===" | tee -a coverage-run.log
-          coverage report -m --fail-under=0 2>&1 | tee -a coverage-run.log
+          coverage run run_tests.py > run_tests.stdout 2> run_tests.stderr
+          run_exit=$?
+          tail -n 40 run_tests.stdout >> coverage-run.log
+          tail -n 80 run_tests.stderr >> coverage-run.log
+          echo "=== coverage run exit=$run_exit ===" | tee -a coverage-run.log
+          coverage report -m --fail-under=0 2>> coverage-run.log | tee -a coverage-run.log
           echo "=== coverage report exit=$? ===" | tee -a coverage-run.log
-          coverage xml 2>&1 | tee -a coverage-run.log
+          # --debug=trace writes very verbose internals; save it to a
+          # sidecar file so the main log stays readable.
+          COVERAGE_DEBUG=trace coverage xml --debug=trace \
+              > coverage-xml.stdout 2> coverage-xml.stderr
           xml_exit=$?
           echo "=== coverage xml exit=$xml_exit ===" | tee -a coverage-run.log
-          # Surface a coverage xml failure only on the canonical cell;
-          # on non-canonical cells we still want the log artefact.
+          echo "--- last 200 lines of coverage xml stderr ---" >> coverage-run.log
+          tail -n 200 coverage-xml.stderr >> coverage-run.log
+          # Surface a coverage xml failure only on the canonical cell.
           if [ "$xml_exit" -ne 0 ] \
               && [ "${{ matrix.python }}" = "3.11" ] \
               && [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            cat coverage-run.log
             exit "$xml_exit"
           fi
+          # Also dump the log to the step summary so it shows up in
+          # the check-run output without downloading artefacts.
+          {
+            echo "### coverage diagnostics (${{ matrix.python }} ${{ matrix.os }})"
+            echo ""
+            echo '```'
+            cat coverage-run.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Enforce coverage floor (ADR-0023)
         # Single canonical cell. Applies the absolute

--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -44,20 +44,32 @@ jobs:
         # Every matrix cell runs the suite under ``coverage`` and
         # emits ``coverage.xml``. The ``fail_under`` floor runs only
         # on the canonical cell (3.11 ubuntu) because coverage is a
-        # single scalar, not a per-Python-version property: different
-        # Python versions legitimately skip different tests (for
-        # example the ``@skipIf(sys.version_info >= (3, 14))``
-        # decorators on the ``typing.Union``-representation tests),
-        # so enforcing the same 100 % floor on every cell would
-        # either be gamed with pragmas or force artificial coverage
-        # of unreachable branches. See ADR-0023 §5.
-        # ``--fail-under=0`` on the shared report step explicitly
-        # overrides the ``fail_under = 100`` in ``.coveragerc`` so
-        # this step never fails on a non-canonical cell.
+        # single scalar, not a per-Python-version property. See
+        # ADR-0023 §5. ``--fail-under=0`` overrides ``.coveragerc``
+        # so this shared step never fails on a non-canonical cell.
+        # ``shell: bash`` makes the step work identically on Windows
+        # (git-bash is always present on the runner) and lets the
+        # ``tee`` / ``PIPESTATUS`` pattern below capture exit codes
+        # into an uploadable log for remote debugging.
+        shell: bash
         run: |
-          coverage run run_tests.py
-          coverage report -m --fail-under=0
-          coverage xml
+          set -o pipefail
+          python --version 2>&1 | tee -a coverage-run.log
+          coverage --version 2>&1 | tee -a coverage-run.log
+          coverage run run_tests.py 2>&1 | tee -a coverage-run.log
+          echo "=== coverage run exit=$? ===" | tee -a coverage-run.log
+          coverage report -m --fail-under=0 2>&1 | tee -a coverage-run.log
+          echo "=== coverage report exit=$? ===" | tee -a coverage-run.log
+          coverage xml 2>&1 | tee -a coverage-run.log
+          xml_exit=$?
+          echo "=== coverage xml exit=$xml_exit ===" | tee -a coverage-run.log
+          # Surface a coverage xml failure only on the canonical cell;
+          # on non-canonical cells we still want the log artefact.
+          if [ "$xml_exit" -ne 0 ] \
+              && [ "${{ matrix.python }}" = "3.11" ] \
+              && [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            exit "$xml_exit"
+          fi
 
       - name: Enforce coverage floor (ADR-0023)
         # Single canonical cell. Applies the absolute
@@ -85,12 +97,15 @@ jobs:
             --fail-under=100
 
       - name: Upload coverage artifact
-        # Every cell produces a coverage.xml. Artifact name includes
-        # the matrix coordinates so they don't collide.
+        # Every cell produces a coverage-run.log (always) and, when
+        # the XML reporter succeeds, coverage.xml. Artifact name
+        # includes the matrix coordinates so uploads don't collide.
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}-py${{ matrix.python }}
-          path: coverage.xml
+          path: |
+            coverage.xml
+            coverage-run.log
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -41,41 +41,30 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with unittest and coverage
-        # Every matrix cell runs the tests under ``coverage`` to
-        # catch Python-version-specific test regressions. Only the
-        # canonical cell (3.11 ubuntu) does the ``fail_under`` floor
-        # check and the ``coverage xml`` / ``diff-cover`` steps.
-        #
-        # Rationale for the canonical-cell split:
-        # - Coverage is a single scalar ("what fraction of pdip/ is
-        #   exercised by the suite"), measured against one Python
-        #   version. Different Python versions legitimately skip
-        #   different tests (for example the
-        #   ``@skipIf(sys.version_info >= (3, 14))`` decorators on
-        #   the ``typing.Union``-representation tests), so enforcing
-        #   the same 100 % floor on every cell would either be gamed
-        #   with pragmas or force artificial coverage of unreachable
-        #   branches. See ADR-0023 §5.
-        # - ``coverage xml`` generation has historically failed on
-        #   Python 3.14 pre-releases; it only exists here to feed
-        #   ``diff-cover``, which itself only runs on the canonical
-        #   cell — no reason to run it elsewhere.
-        # - ``--fail-under=0`` on the report step explicitly
-        #   overrides the ``fail_under = 100`` in ``.coveragerc`` so
-        #   this shared step never fails on a matrix cell that is
-        #   not the enforcer.
+        # Every matrix cell runs the suite under ``coverage`` and
+        # emits ``coverage.xml``. The ``fail_under`` floor runs only
+        # on the canonical cell (3.11 ubuntu) because coverage is a
+        # single scalar, not a per-Python-version property: different
+        # Python versions legitimately skip different tests (for
+        # example the ``@skipIf(sys.version_info >= (3, 14))``
+        # decorators on the ``typing.Union``-representation tests),
+        # so enforcing the same 100 % floor on every cell would
+        # either be gamed with pragmas or force artificial coverage
+        # of unreachable branches. See ADR-0023 §5.
+        # ``--fail-under=0`` on the shared report step explicitly
+        # overrides the ``fail_under = 100`` in ``.coveragerc`` so
+        # this step never fails on a non-canonical cell.
         run: |
           coverage run run_tests.py
           coverage report -m --fail-under=0
-
-      - name: Enforce coverage floor + generate XML (ADR-0023, ADR-0027)
-        # Single canonical cell. Generates coverage.xml for the
-        # diff-cover step that follows, and applies the absolute
-        # ``fail_under = 100`` floor from .coveragerc.
-        if: matrix.python == '3.11' && matrix.os == 'ubuntu-latest'
-        run: |
           coverage xml
-          coverage report --fail-under=100
+
+      - name: Enforce coverage floor (ADR-0023)
+        # Single canonical cell. Applies the absolute
+        # ``fail_under = 100`` from .coveragerc against the report
+        # already generated above.
+        if: matrix.python == '3.11' && matrix.os == 'ubuntu-latest'
+        run: coverage report --fail-under=100
 
       - name: Enforce 100 % diff coverage on changed lines (ADR-0027)
         # Runs only on pull requests, on one matrix cell (avoids
@@ -96,16 +85,12 @@ jobs:
             --fail-under=100
 
       - name: Upload coverage artifact
-        # Only the canonical cell produces coverage.xml (see above);
-        # uploading the same artefact from every cell would collide
-        # on name anyway.
-        if: >
-          always()
-          && matrix.python == '3.11'
-          && matrix.os == 'ubuntu-latest'
+        # Every cell produces a coverage.xml. Artifact name includes
+        # the matrix coordinates so they don't collide.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-xml
+          name: coverage-${{ matrix.os }}-py${{ matrix.python }}
           path: coverage.xml
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ for the public API surface described in
 
 ### Changed
 
+- **`coverage` bumped 7.6.12 → 7.13.5.** The 7.6.12 pin predated
+  upstream's stable Python 3.14 support; `coverage xml` and
+  `coverage html` failed on the 3.14 matrix cells (ast-module
+  changes in the 3.14 pre-release). The ratchet PR (#84) worked
+  around this by scoping XML generation to the canonical 3.11
+  ubuntu cell. 7.13.5 handles 3.14 cleanly, so XML generation is
+  back on every matrix cell and each cell uploads its own
+  `coverage-<os>-py<version>` artefact.
 - **Coverage floor ratcheted 95 → 100 %** per ADR-0023. Measured
   coverage at the time of this ratchet is **100 %** (3724/3724
   statements) across **664** unit tests, lifted by a four-PR push

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coverage==7.6.12
+coverage==7.13.5
 diff-cover==9.2.0
 cryptography==46.0.7
 dataclasses-json==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coverage==7.13.5
+coverage==7.10.7
 diff-cover==9.2.0
 cryptography==46.0.7
 dataclasses-json==0.6.7


### PR DESCRIPTION
## Closing without merging — investigation result

**Goal:** remove the canonical-cell workaround from #84 and run `coverage xml` on every matrix cell again, by bumping coverage.py to a version that handles Python 3.14 cleanly.

**Result of investigation:**

| coverage version | 3.9 support | 3.14 `coverage xml` |
|---|---|---|
| `7.6.12` (pre-ratchet) | ✅ | ❌ fails |
| `7.13.5` (latest) | ❌ (`requires_python >= 3.10`) | ❌ still fails |
| `7.10.7` (last version supporting both 3.9 and 3.14 classifiers) | ✅ | ❌ still fails |

No currently-released coverage.py version both supports our floor (Python 3.9 per ADR-0020) **and** generates valid XML on Python 3.14 runners. The `coverage xml` step fails on all three 3.14 cells (ubuntu, macos, windows) across every version tried.

**Conclusion:** the canonical-cell workaround from PR #84 is the right design for now, not a stopgap:

- Coverage is a scalar property of the codebase+tests, measured against one Python version (ADR-0023 §5).
- `diff-cover` requires `coverage.xml`, but it also runs only on the canonical 3.11 ubuntu cell, so there's no need to regenerate the same XML from every cell.
- When a coverage.py release lands that fixes 3.14 XML generation while keeping 3.9 supported, a follow-up PR (≤ 5 lines of workflow diff) can roll this out.

Closing without merging to keep the history tidy. The action on main is green and the design rationale is documented in the ADR.

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX