### PR TITLE
docs(readme): make coverage + quality methodology explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
     <a href="https://github.com/ahmetcagriakca/pdip/actions/workflows/package-build-and-tests.yml" target="_blank">
         <img src="https://github.com/ahmetcagriakca/pdip/actions/workflows/package-build-and-tests.yml/badge.svg" alt="Build status">
     </a>
+    <a href="#testing-and-quality">
+        <img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage 100%">
+    </a>
+    <a href="#testing-and-quality">
+        <img src="https://img.shields.io/badge/tests-664%20unit-blue" alt="664 unit tests">
+    </a>
+    <a href="docs/governance/adr/0027-tdd-with-diff-coverage.md">
+        <img src="https://img.shields.io/badge/workflow-TDD%20%2B%20diff--cover-informational" alt="TDD + diff-cover">
+    </a>
 </p>
 
 # pdip — Python Data Integrator
@@ -33,6 +42,7 @@ endpoint by adding one file — not by wiring plumbing.
 - [Example — a REST endpoint](#example--a-rest-endpoint)
 - [Example — an ETL integration](#example--an-etl-integration)
 - [Project layout](#project-layout)
+- [Testing and quality](#testing-and-quality)
 - [Development](#development)
 - [Documentation and governance](#documentation-and-governance)
 - [License](#license)
@@ -223,23 +233,113 @@ pdip/
 └── utils/              Small helpers
 ```
 
+## Testing and quality
+
+pdip is test-first with mechanically enforced quality gates. The
+numbers are not goals to aspire to — they are **hard gates that fail
+CI** the moment they regress.
+
+### The gates
+
+| Gate | What it enforces | Source of truth | Breaks CI on regression? |
+|---|---|---|---|
+| **`fail_under = 100`** | Line coverage of `pdip/` never drops below **100 %** | [`.coveragerc`](.coveragerc) | ✅ |
+| **`diff-cover --fail-under=100`** | Every newly added or modified `pdip/` line in a PR is covered | [ADR-0027](docs/governance/adr/0027-tdd-with-diff-coverage.md) | ✅ (PR-only) |
+| **`quality_guard` meta-tests** | Six [ADR-0026](docs/governance/adr/0026-test-quality-rules.md) / ADR-0027 rules (see below) | [`tests/unittests/quality_guard/test_conventions.py`](tests/unittests/quality_guard/test_conventions.py) | ✅ |
+| **15-cell CI matrix** | Python **3.10–3.14** × Linux/macOS/Windows | [`package-build-and-tests.yml`](.github/workflows/package-build-and-tests.yml) | ✅ |
+
+### Current measurement
+
+- **664 unit tests** under `tests/unittests/`
+- **3724 / 3724 statements covered** — `TOTAL 100%`
+- Integration adapters (`pdip/integrator/connection/types/{sql,bigdata,webservice,file,inmemory,queue}/*`) and the
+  parallel-strategy subprocess paths are excluded from unit-coverage
+  measurement ([ADR-0023 §1](docs/governance/adr/0023-coverage-floor-policy.md)); they are exercised by
+  `tests/integrationtests/` which is run locally against real backends.
+
+### The workflow: TDD, then diff-cover, then floor
+
+[**ADR-0027 — Test-first development with diff-coverage enforcement**](docs/governance/adr/0027-tdd-with-diff-coverage.md)
+pins the workflow:
+
+1. Write the failing test first. Watch it fail for the right reason.
+2. Write the smallest production change that makes it pass.
+3. `diff-cover` against the merge-base with `main` must be **100 %**.
+4. `fail_under = 100` (total coverage) must still hold.
+
+If you absolutely must exclude a line from coverage, use
+`# pragma: no cover — <reason>` **with an inline reason on the same
+line**; the `quality_guard` suite fails CI if the reason is missing
+(ADR-0027 §5).
+
+### The six machine-checked quality rules
+
+The meta-test suite under [`tests/unittests/quality_guard/`](tests/unittests/quality_guard/)
+is what makes [ADR-0026](docs/governance/adr/0026-test-quality-rules.md) real. It fails CI when any of these are violated:
+
+| Rule | What it rejects |
+|---|---|
+| **A.1** | Any `test_*` method that does not contain an `assert` / `self.assert*` call |
+| **A.2** | Tautological assertions (`assertEqual(x, x)`, `assertTrue(True)`, etc.) |
+| **D.1** | `time.sleep(>= 0.1)` in unit tests (keeps the suite deterministic and fast) |
+| **F.1** | `import pytest` anywhere under `tests/unittests/` — we are `unittest`-only per [ADR-0018](docs/governance/adr/0018-testing-strategy.md) |
+| **F.2** | `from X import *` in test files — star imports are rejected |
+| **ADR-0027 §5** | `# pragma: no cover` without an inline reason comment on the same line |
+
+Beyond these six, [ADR-0026](docs/governance/adr/0026-test-quality-rules.md) also requires AAA structure, mocks at
+boundaries only, and concrete behavioural assertions — enforced by
+review rather than mechanically.
+
+### Running the quality loop locally
+
+```bash
+# Full suite (same run command CI uses)
+coverage run run_tests.py
+
+# Absolute 100 % floor, same as the canonical CI cell
+coverage report -m --fail-under=100
+
+# Per-PR diff coverage: every line you added must be covered
+coverage xml
+diff-cover coverage.xml --compare-branch origin/main --fail-under=100
+
+# ADR-0026 / ADR-0027 machine-checked rules
+python -m unittest tests.unittests.quality_guard.test_conventions
+```
+
+The CI matrix in [`package-build-and-tests.yml`](.github/workflows/package-build-and-tests.yml) runs the suite on every
+combination of Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 × Linux /
+macOS / Windows (**15 cells**). The `fail_under=100` gate and
+`coverage xml` generation are scoped to the canonical 3.11 ubuntu
+cell per [ADR-0023 §5](docs/governance/adr/0023-coverage-floor-policy.md) — coverage is a scalar property of the
+codebase, not a per-Python-version property, and different versions
+legitimately skip different tests (e.g. the
+`@skipIf(sys.version_info >= (3, 14))` decorators on the
+`typing.Union`-representation tests). Other cells still run the
+full suite under `coverage run` so Python-version test regressions
+are caught.
+
+Detailed test commands — integration tests, database fixtures,
+single-file runs — are in [`readme.test.md`](readme.test.md).
+
 ## Development
 
 ```bash
-# Install development dependencies
+# Install pinned tooling (coverage, diff-cover, flake8, cryptography, etc.)
 pip install -r requirements.txt
 
-# Run the unit and integration test suite
+# Run the unit test suite
 python run_tests.py
 
-# Run with coverage (same as CI)
-coverage run --source=pdip run_tests.py
-coverage report -m --omit="*/tests/*,*/site-packages/*"
+# Verify locally what CI will enforce
+coverage run run_tests.py
+coverage report --fail-under=100
+python -m unittest tests.unittests.quality_guard.test_conventions
 ```
 
-Detailed test commands are in [`readme.test.md`](readme.test.md).
-CI runs `package-build-and-tests.yml` on Python 3.10–3.14 across Linux,
-macOS, and Windows.
+Python **3.10–3.14** are supported; see
+[ADR-0028](docs/governance/adr/0028-raise-python-floor-to-3-10.md)
+for why the floor is 3.10.
 
 ## Documentation and governance
 


### PR DESCRIPTION
## Summary

The README was thin on how pdip actually enforces quality. A new reader saw "Python 3.10+ is supported" and a bare `coverage run` command, and had to read four ADRs to learn that:

- Coverage is locked at **100 %** via `.coveragerc` `fail_under = 100`.
- Every PR line is gated by `diff-cover --fail-under=100`.
- Six machine-checked rules in `tests/unittests/quality_guard/` fail CI on assertion / pragma / sleep / pytest / star-import violations.
- CI runs on a 15-cell matrix (3.10–3.14 × Linux/macOS/Windows).

This PR makes all of that explicit in one place.

### What's added

- **Three new badges**: coverage 100 %, 664 unit tests, TDD + diff-cover.
- **New `## Testing and quality` section** with six sub-blocks:
  1. **Gates table** — each CI-failing gate, what it enforces, and the source of truth.
  2. **Current measurement** — 664 tests, 3724/3724 statements, plus the integration-adapter exclusion rationale linked to ADR-0023 §1.
  3. **TDD workflow** — the ADR-0027 four-step loop (failing test → smallest change → diff-cover → floor) and the `# pragma: no cover — <reason>` rule.
  4. **Six machine-checked rules** table — A.1/A.2/D.1/F.1/F.2 + ADR-0027 §5.
  5. **Running the quality loop locally** — exact commands mirroring CI.
  6. **CI matrix rationale** — why 15 cells run the suite but only the canonical 3.11 ubuntu cell enforces the floor and generates XML (per ADR-0023 §5).
- **Slimmed Development section** focused on "how to verify locally what CI will enforce", with a pointer to ADR-0028 for the Python floor.

### Cross-references

Every number / rule in the new sections links back to its source of truth:

| Link | Target |
|---|---|
| `.coveragerc` | fail_under source |
| `tests/unittests/quality_guard/test_conventions.py` | the six rules themselves |
| `.github/workflows/package-build-and-tests.yml` | the CI matrix |
| ADR-0018 | unittest-only policy |
| ADR-0023 | coverage floor + canonical-cell scoping |
| ADR-0026 | test quality rules |
| ADR-0027 | TDD + diff-cover + pragma-with-reason rule |
| ADR-0028 | Python 3.10+ floor |

## Test plan

- [x] `python -m unittest tests.unittests.quality_guard.test_conventions` — 6/6 pass
- [x] Markdown renders cleanly in the README (tables, code blocks, links)
- [ ] CI stays green (only `README.md` changes, no `pdip/` lines touched → diff-cover is a no-op)

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_