### PR TITLE
feat(devx): pre-commit hooks for quality_guard + CI-matching flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+# Pre-commit hooks for pdip. Install with ``pre-commit install`` after
+# ``pip install -r requirements.txt``.
+#
+# The hooks mirror the ADR-0026 / ADR-0027 §5 machine-checked rules
+# and the same flake8 selection as CI so a green pre-commit implies
+# that the corresponding CI steps will stay green. Everything here
+# is fast (< 2 s total) — the full suite and diff-cover remain on
+# CI where they belong.
+
+default_language_version:
+  python: python3.11
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        # Markdown uses two trailing spaces for a hard line break;
+        # leave those alone so we don't fight with rendered output.
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        # Matches the blocking flake8 invocation in
+        # .github/workflows/package-build-and-tests.yml so a green
+        # pre-commit implies a green CI lint step.
+        args:
+          - --count
+          - --select=E9,F63,F7,F82,E711,E712,E722
+          - --show-source
+          - --statistics
+
+  - repo: local
+    hooks:
+      - id: quality-guard
+        name: ADR-0026 / ADR-0027 §5 quality rules
+        # Runs the six machine-enforced rules from
+        # tests/unittests/quality_guard/test_conventions.py:
+        #   A.1 every test_* method has an assertion,
+        #   A.2 no tautological assertions,
+        #   D.1 no time.sleep >= 0.1 in unit tests,
+        #   F.1 no pytest imports (unittest-only per ADR-0018),
+        #   F.2 no star imports in tests/,
+        #   ADR-0027 §5 every ``# pragma: no cover`` carries an
+        #     inline reason comment on the same line.
+        # The suite runs in ~300 ms locally — well within budget
+        # for pre-commit.
+        entry: python -m unittest tests.unittests.quality_guard.test_conventions
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -8,12 +8,14 @@ context.
 
 ## Prerequisites
 
-- **Python 3.9+** (both the CI matrix floor and the package's
+- **Python 3.10+** (both the CI matrix floor and the package's
   `python_requires` declaration; see
+  [ADR-0028](../governance/adr/0028-raise-python-floor-to-3-10.md),
+  which supersedes the floor half of
   [ADR-0020](../governance/adr/0020-raise-python-floor-to-3-9.md)).
 - `git`.
 - A C toolchain if you plan to install the `[integrator]` extra from
-  source: `cx_Oracle`, `pyodbc`, `psycopg2`, and `mysql-connector` can
+  source: `oracledb`, `pyodbc`, `psycopg2`, and `mysql-connector` can
   require system libraries on some platforms.
 
 ## Clone and install
@@ -40,16 +42,39 @@ pip install -e ".[integrator]"
 pip install -e ".[api,integrator,cryptography]"
 ```
 
+## Install pre-commit hooks
+
+pdip uses [pre-commit](https://pre-commit.com/) to run the
+ADR-0026 / ADR-0027 §5 quality rules and the same blocking flake8
+selection as CI **before** a commit leaves your machine. This
+catches the common violations (missing assertion, tautology,
+pragma-without-reason, star import, long sleep) in ~300 ms instead
+of waiting for CI.
+
+```bash
+# ``pre-commit`` is already listed in requirements.txt, so it is
+# installed by the step above. Register the git hook once:
+pre-commit install
+
+# Optionally run every hook against every file right now (normally
+# pre-commit only runs on staged files at commit time):
+pre-commit run --all-files
+```
+
+Uninstall later with `pre-commit uninstall` if you ever need the
+raw `git commit` behaviour back.
+
 ## Run the tests
 
 ```bash
-# All unit and integration tests (same as CI)
+# All unit tests (same as CI)
 python run_tests.py
 
-# With coverage
-coverage run --source=pdip run_tests.py
-coverage report -m --omit="*/tests/*,*/site-packages/*"
-coverage html --omit="*/tests/*,*/site-packages/*"   # writes htmlcov/
+# With coverage — ``.coveragerc`` at the repo root owns the
+# source + omit + fail_under settings, so no flags needed.
+coverage run run_tests.py
+coverage report --fail-under=100
+coverage html                                        # writes htmlcov/
 ```
 
 More granular test invocations (per module, with `--locals`, etc.) are
@@ -58,17 +83,36 @@ in [`../../readme.test.md`](../../readme.test.md).
 ## Linting
 
 CI runs `flake8` with two passes — see
-[`.github/workflows/package-build-and-tests.yml`](../../.github/workflows/package-build-and-tests.yml):
+[`.github/workflows/package-build-and-tests.yml`](../../.github/workflows/package-build-and-tests.yml).
+The pre-commit hook (registered above) runs the blocking pass
+locally before each commit; the warning pass is advisory and
+runs only on CI.
 
 ```bash
 pip install flake8
 
-# Fail on syntax errors / undefined names (CI hard-fails on this)
-flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# Blocking pass: hard-fails CI on any hit. Matches the pre-commit
+# hook in .pre-commit-config.yaml.
+flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics
 
-# Warnings pass (CI runs with --exit-zero)
+# Advisory pass: CI runs with --exit-zero so warnings never block.
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 ```
+
+## Run the machine-checked quality rules
+
+The six ADR-0026 / ADR-0027 §5 rules live in a single `unittest`
+module and are run automatically by the `pre-commit` hook above,
+by CI, and can be invoked directly:
+
+```bash
+python -m unittest tests.unittests.quality_guard.test_conventions
+```
+
+A hit from this suite blocks the commit / CI run; see
+[ADR-0026](../governance/adr/0026-test-quality-rules.md) and
+[ADR-0027](../governance/adr/0027-tdd-with-diff-coverage.md) for
+the rules and the rationale.
 
 ## Branching
 
@@ -83,9 +127,14 @@ the template.
 
 ## Troubleshooting
 
-- **`cx_Oracle` fails to install.** Install the Oracle Instant Client
-  for your platform and export its path (`LD_LIBRARY_PATH` on Linux,
-  `DYLD_LIBRARY_PATH` on macOS, `PATH` on Windows).
+- **`oracledb` thin-mode isn't enough.** The `[integrator]` extra
+  installs `python-oracledb` (per
+  [ADR-0021](../governance/adr/0021-cx-oracle-to-python-oracledb.md)),
+  which runs in pure-Python thin mode by default — no Instant Client
+  required. If you need thick mode for an older Oracle server, install
+  the Oracle Instant Client for your platform and export its path
+  (`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on macOS, `PATH` on
+  Windows).
 - **`pyodbc` fails to install.** Install an ODBC development package
   (`unixodbc-dev` on Debian/Ubuntu, `unixodbc` via Homebrew on macOS).
 - **Tests cannot find a database.** Integration tests under

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coverage==7.13.5
 diff-cover==9.2.0
+pre-commit==4.0.1
 cryptography==46.0.7
 dataclasses-json==0.6.7
 Flask==3.1.3


### PR DESCRIPTION
## Summary

Adds [`pre-commit`](https://pre-commit.com/) so the ADR-0026 / ADR-0027 §5 machine-checked rules and the blocking flake8 pass run **before a commit leaves the developer's machine**, instead of waiting for CI to catch them 5–7 minutes later.

Until today the feedback loop was: write code → `git push` → wait for the CI matrix → discover you forgot an assertion, wrote a pytest-ism, left a long `time.sleep`, or dropped a `# pragma: no cover` without a reason → push a fixup. The hook suite runs in ~300 ms locally.

## What the hooks enforce

| Hook | What it catches | Source |
|---|---|---|
| `trailing-whitespace` (markdown-safe), `end-of-file-fixer`, `check-yaml`, `check-toml`, `check-merge-conflict`, `check-added-large-files` (< 500 KB), `mixed-line-ending` (LF) | Hygiene regressions — trailing whitespace, missing final newline, CRLF sneaking in on Windows, accidentally-committed binaries, leftover merge markers. | `pre-commit-hooks@v5.0.0` |
| `flake8` with `--select=E9,F63,F7,F82,E711,E712,E722` | **Exact same** blocking selection as the CI workflow's first flake8 pass. A green pre-commit therefore implies a green CI lint step. | `flake8@7.1.1` + [`package-build-and-tests.yml`](.github/workflows/package-build-and-tests.yml) |
| **`quality-guard`** (local hook) | The six ADR-0026 / ADR-0027 §5 rules: A.1 (every `test_*` asserts), A.2 (no tautologies), D.1 (no long sleeps), F.1 (no pytest), F.2 (no star imports), ADR-0027 §5 (every `# pragma: no cover` has an inline reason). | `tests/unittests/quality_guard/test_conventions.py` — invoked directly, no duplication. |

## Install flow for contributors

```bash
pip install -r requirements.txt     # now pulls pre-commit==4.0.1
pre-commit install                   # register the git hook once
```

Documented in [`docs/contributing/setup.md`](docs/contributing/setup.md) alongside an explicit "Run the machine-checked quality rules" section that names the rules and links to their ADRs.

## Along the way — stale setup docs refreshed

The setup doc had a couple of leftover references that I fixed in-scope since they're part of the "onboarding" path:

- `Python 3.9+` → `Python 3.10+` (per ADR-0028, already shipped in 0.8.0).
- `cx_Oracle` troubleshooting → `oracledb` thin/thick mode note (per ADR-0021).
- `coverage run --source=pdip` + `coverage report -m --omit=...` → bare `coverage run` + `coverage report --fail-under=100`, because `.coveragerc` now owns those settings (ADR-0023 §5).

## Test plan

- [x] `pre-commit validate-config` → exit 0
- [x] `python -m unittest tests.unittests.quality_guard.test_conventions` → 6/6 OK
- [x] `flake8 . --count --select=E9,F63,F7,F82,E711,E712,E722 --show-source --statistics` → no violations
- [ ] CI stays green on this PR (only `.pre-commit-config.yaml`, `requirements.txt`, and `docs/contributing/setup.md` change — no `pdip/` lines touched, diff-cover is a no-op)

## Why add it now, not later?

The quality gates exist (ADR-0026, ADR-0027). What was missing was surfacing them early. Pre-commit is a one-file config + docs change: high ROI, tight scope, no runtime surface change. See the recent backlog discussion — this was priority #2 after the 0.8.0 release.

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_