### PR TITLE
security(ci): SHA-pin every GitHub Action + cover with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,19 @@ updates:
           - "mysql-connector-python"
           - "pyodbc"
           - "pandas"
+
+  # SHA-pinned GitHub Actions (supply-chain hardening) must be kept
+  # fresh. Dependabot rewrites both the ``@<sha>`` pin and the trailing
+  # ``# <tag>`` comment in-place when a new minor / patch tag is
+  # published. Grouped into a single weekly PR so each release of
+  # actions/checkout etc. does not fragment the review queue.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,11 +23,11 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2
 
       - name: Auto-merge patch bumps that do not touch integrator extras
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,8 +38,8 @@ jobs:
     name: Build mkdocs site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
       - name: Install mkdocs-material
@@ -57,7 +57,7 @@ jobs:
           github.event_name == 'push'
           && github.ref == 'refs/heads/main'
           && vars.PAGES_ENABLED == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: _site
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only runs on a push to main AND after the admin has opted in
     # by setting the repository variable ``PAGES_ENABLED = true``.
-    # Without the gate, the step ``actions/deploy-pages@v4`` fails
+    # Without the gate, the step ``actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4`` fails
     # hard because the repo's Pages API returns 404. Skipping
     # cleanly keeps the main branch check-page green.
     if: >
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -19,13 +19,13 @@ jobs:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
         python: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # diff-cover needs the merge-base to exist locally so it can
           # compute "lines changed since main" on pull-request builds.
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -104,7 +104,7 @@ jobs:
           always()
           && matrix.python == '3.11'
           && matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: coverage-xml
           path: coverage.xml

--- a/.github/workflows/python-upload-package.yml
+++ b/.github/workflows/python-upload-package.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -81,7 +81,7 @@ jobs:
         # CHANGELOG.md; if no section is found, falls back to the
         # tag annotation message. Consumers see a rendered Markdown
         # release page with the same content as the CHANGELOG.
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: ${{ steps.tag.outputs.name }}
           name: ${{ steps.tag.outputs.name }}

--- a/.github/workflows/python-upload-test-package.yml
+++ b/.github/workflows/python-upload-test-package.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

Supply-chain hardening for GitHub Actions. Replaces every floating `@vN` reference across the five workflow files with the pinned commit SHA, annotated with a trailing `# vN` comment so humans (and Dependabot) can still tell what version it was pinned from.

### Why pin

A floating tag like `actions/checkout@v4` resolves to whatever commit the tag currently points at. An attacker who compromises the Actions marketplace repo can push a new commit to that tag and instantly execute arbitrary code in every downstream CI run. The [OWASP / OpenSSF guidance on hardening GitHub Actions](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms) puts unpinned third-party actions in the top-5 CI/CD risks.

SHA-pinning makes tampering visible in a PR diff. The attacker has to convince a reviewer to approve a changed SHA, which is much louder than moving a tag.

### Actions pinned

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-python` | v5 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/deploy-pages` | v4 | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
| `actions/upload-pages-artifact` | v3 | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
| `dependabot/fetch-metadata` | v2 | `21025c705c08248db411dc16f3619e6b5f9ea21a` |
| `softprops/action-gh-release` | v2 | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |

Each SHA resolved via `GET /repos/:owner/:repo/commits/:tag` on 2026-04-24 — pointing at exactly the commit `@vN` currently resolves to, so **no functional change** in any workflow.

### Keeping pins fresh

Pinning alone is insufficient — without automation, pins ossify and miss legitimate security patches. This PR also:

- Adds a `github-actions` ecosystem entry to `.github/dependabot.yml` with a single group (pattern `*`) so all action bumps arrive as one weekly PR.
- The existing `dependabot-auto-merge.yml` already auto-merges `version-update:semver-patch` Dependabot PRs regardless of ecosystem, so patch bumps of actions (e.g. `setup-python v5.1.7 → v5.1.8`) auto-land. Major-version bumps (e.g. `setup-python v5 → v6`) stay queued for review, which is correct — those often have breaking changes.

Dependabot rewrites both the `@<sha>` pin and the trailing `# <tag>` comment in-place when updating, so the annotation stays accurate.

## Why pair pin + auto-bot in one PR

Merging just the pins without the Dependabot ecosystem entry leaves the pins frozen — worse than floating tags because they miss security patches and nobody notices until something breaks. The two changes are a single unit of work.

## Test plan

- [x] `grep 'uses: .*@v[0-9]\+$' -r .github/workflows/` — zero hits; no un-pinned floating tag remains.
- [x] Dependabot config parses (no YAML syntax issues).
- [ ] CI matrix stays green on this PR (no `pdip/` lines touched → diff-cover is a no-op; workflow runs themselves exercise every pinned action).
- [ ] Next weekly Dependabot cycle produces a single `chore(ci): bump the github-actions group` PR bundling all the pending action bumps.

## Out of scope

- `SECURITY.md` still carries the GitHub default template text. Separate hardening PR should replace it with a project-specific reporting flow + supported-versions table.
- SBOM generation (CycloneDX artefacts on release). Good follow-up.
- Signed-commit / signed-tag enforcement per ADR-0024 §2. Referenced there as a known gap; worth its own security ADR.

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_