### PR TITLE
feat(ci): nightly integration-tests workflow (ADR-0029) — postgres + mysql

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,140 @@
+# Nightly + manual integration-test run against real database backends.
+#
+# The main CI workflow (``package-build-and-tests.yml``) only runs the
+# unit suite under ``tests/unittests/``. Adapter code under
+# ``pdip/integrator/connection/types/{sql,bigdata,webservice}/`` is
+# excluded from that run's coverage measurement per ADR-0023 §1 — it
+# cannot be exercised without a real backend.
+#
+# This workflow closes the loop. It boots the pinned Docker images
+# from ``tests/environments/<backend>/docker-compose.yml`` as
+# ``services:`` containers and runs the corresponding
+# ``tests/integrationtests/integrator/integration/sql/<backend>/``
+# module against them.
+#
+# Why nightly (not per-push)?
+# - Integration runs are slower (~3–5 min/backend); running per-push
+#   would dilute the 2-min feedback loop contributors rely on.
+# - Flaky connection / startup timing issues show as noise on PRs.
+#   Nightly absorbs them.
+# - The real value is catching driver-bump / image-bump regressions,
+#   which surface on a day-scale, not a commit-scale.
+# - Manual ``workflow_dispatch`` is always available for on-demand
+#   runs (e.g. just after a Dependabot image bump merges).
+#
+# See ADR-0029 for the full rationale.
+
+name: Integration tests (nightly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 04:00 UTC. Deliberately late in the European evening
+    # / early morning to avoid GitHub Actions queue pressure.
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  # ------------------------------------------------------------------
+  postgres:
+    name: Postgres 16
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Pinned to the same image as
+    # ``tests/environments/postgresql/docker-compose.yml``.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pdi
+          POSTGRES_PASSWORD: pdi!123456
+          POSTGRES_DB: test_pdi
+        ports:
+          # The integration tests hard-code 5434 on the host (matching
+          # the docker-compose fixture); map it through to the 5432
+          # inside the container.
+          - 5434:5432
+        options: >-
+          --health-cmd=pg_isready
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies (runtime + integrator extra)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e ".[integrator]"
+
+      - name: Provision ``test_pdi`` schema inside the ``test_pdi`` database
+        # The tests expect a schema named ``test_pdi``; ``POSTGRES_DB``
+        # only creates the database. Create the schema idempotently so
+        # a retried workflow does not fail on "schema exists".
+        env:
+          PGPASSWORD: "pdi!123456"
+        run: |
+          psql -h 127.0.0.1 -p 5434 -U pdi -d test_pdi \
+               -c "CREATE SCHEMA IF NOT EXISTS test_pdi;"
+
+      - name: Run postgres integration tests
+        run: |
+          python -m unittest discover \
+              -s tests/integrationtests/integrator/integration/sql/postgresql \
+              -t . \
+              -v
+
+  # ------------------------------------------------------------------
+  mysql:
+    name: MySQL 8.4
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Pinned to the same image as
+    # ``tests/environments/mysql/docker-compose.yml``.
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: test_pdi
+          MYSQL_USER: pdi
+          MYSQL_PASSWORD: pdi!123456
+          MYSQL_ROOT_PASSWORD: pdi!123456
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies (runtime + integrator extra)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e ".[integrator]"
+
+      - name: Run MySQL integration tests
+        run: |
+          python -m unittest discover \
+              -s tests/integrationtests/integrator/integration/sql/mysql \
+              -t . \
+              -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,56 @@ for the public API surface described in
 
 ## [Unreleased]
 
-_No changes yet — `0.8.0` is the current release._
+### Added
+
+- **ADR-0029 — Integration tests run nightly in CI.** New
+  `.github/workflows/integration-tests.yml` boots the pinned
+  Postgres 16 and MySQL 8.4 images (from
+  `tests/environments/<backend>/docker-compose.yml`) as Actions
+  `services:` containers and runs the matching modules under
+  `tests/integrationtests/integrator/integration/sql/<backend>/`.
+  Triggers: `workflow_dispatch` + daily cron at 04:00 UTC. **Not**
+  on `push` / `pull_request` — the main CI loop stays sub-2-min.
+  MSSQL / Oracle / Kafka jobs arrive as follow-up PRs.
+- New `examples/crud_api/` — runnable minimal CQRS + REST +
+  SQLAlchemy "notes" service; boots via `python examples/crud_api/main.py`.
+  Backed by `tests/unittests/examples/crud_api/test_crud_api_example.py`
+  so CI catches any framework change that regresses the example.
+- `.pre-commit-config.yaml` — runs the 6 ADR-0026/0027 §5 quality
+  rules and the CI-matching blocking flake8 pass locally in
+  ~300 ms before every commit. Registered via
+  `pre-commit install` after `pip install -r requirements.txt`.
+- `tests/environments/README.md` — single table listing every
+  docker-compose fixture, pinned image version, port, credentials,
+  and maintenance status.
+- `docs/governance/upstream-coverage-py-3.14-xml-issue.md` — draft
+  bug report for the `coverage xml` failure on Python 3.14 runners
+  (PR #94), to be filed at `nedbat/coveragepy` once 3.14 reaches
+  final. ADR-0028's Follow-ups bullet links to it as the
+  deprecation trigger for the canonical-cell workaround.
+
+### Changed
+
+- **SHA-pinned every GitHub Action** across all five workflow
+  files — `actions/checkout`, `actions/setup-python`,
+  `actions/upload-artifact`, `actions/deploy-pages`,
+  `actions/upload-pages-artifact`, `dependabot/fetch-metadata`,
+  `softprops/action-gh-release`. Each pin annotated with a
+  trailing `# vN` comment for readability and Dependabot
+  compatibility. Dependabot now tracks the `github-actions`
+  ecosystem alongside `pip`, keeping the pins fresh without
+  ossifying on security updates.
+- **Docker-compose fixtures under `tests/environments/` stabilised
+  to current LTS / stable releases:** MySQL `5.7 → 8.4` (EOL
+  bump), Postgres `latest → 16-alpine` (pin), MSSQL
+  `2017-latest-ubuntu → 2022-latest`, Oracle `daggerok/oracle:se →
+  gvenzl/oracle-xe:21-slim-faststart`, Confluent Kafka +
+  ZooKeeper `latest → 7.7.1`. Removed the deprecated `version: ...`
+  key from every compose file. Hadoop + Impala fixtures kept on
+  legacy pins with explicit `# unmaintained; see header` markers
+  pending their migration.
+
+## [0.8.0] — 2026-04-24
 
 ## [0.8.0] — 2026-04-24
 

--- a/docs/governance/adr/0029-integration-tests-in-ci.md
+++ b/docs/governance/adr/0029-integration-tests-in-ci.md
@@ -1,0 +1,206 @@
+# ADR-0029: Integration tests run nightly in CI
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Deciders:** pdip maintainers
+- **Tags:** testing, ci, quality, integration
+- **Extends:** [ADR-0018](./0018-testing-strategy.md)
+- **Relates to:** [ADR-0023](./0023-coverage-floor-policy.md) (the
+  `.coveragerc` omit list this ADR fills in for),
+  [ADR-0025](./0025-dependabot-auto-merge-policy.md) (Docker image
+  bumps reach this workflow via the Dependabot ecosystem added in
+  the SHA-pin PR).
+
+## Context
+
+`tests/integrationtests/` has existed in the repository since the
+0.7.0 baseline, but nothing in CI has ever run it. Until this ADR
+lands, the integration test modules under
+
+```
+tests/integrationtests/integrator/integration/sql/{mysql,postgresql,mssql,oracle}/
+tests/integrationtests/integrator/connection/{sql,bigdata,inmemory,queue}/…
+```
+
+were runnable only by a contributor who:
+
+1. Had Docker installed locally.
+2. Knew to start the right `tests/environments/<backend>/docker-compose.yml`.
+3. Ran `python -m unittest tests.integrationtests.<path>` by hand.
+
+In practice, nobody does step 2 routinely. The adapter code under
+`pdip/integrator/connection/types/{sql,bigdata,webservice,file,inmemory,queue}/`
+is therefore covered by **no regression signal** — it is explicitly
+excluded from unit-coverage per [ADR-0023 §1](./0023-coverage-floor-policy.md)
+and has no CI equivalent. A driver bump (`python-oracledb`,
+`confluent-kafka`, `mysql-connector-python`) that breaks the adapter
+surface lands to `main` invisibly until a downstream consumer files
+a bug.
+
+The gap closed by this ADR.
+
+## Decision
+
+### 1. A new scheduled workflow runs integration tests against real backends
+
+`.github/workflows/integration-tests.yml` boots each backend's
+pinned Docker image (the ones maintained under
+`tests/environments/<backend>/docker-compose.yml` per the 2026-04-24
+image-stabilisation pass) as a GitHub Actions `services:` container
+and runs the matching test module against it.
+
+### 2. Triggers
+
+| Trigger | When |
+|---|---|
+| `schedule: cron: "0 4 * * *"` | Daily at 04:00 UTC. |
+| `workflow_dispatch` | Any maintainer can run it on demand from the Actions tab. |
+
+**Not** triggered on `push` or `pull_request`. The main CI workflow
+(`package-build-and-tests.yml`) stays focused on the fast unit-test
+path (< 2 min feedback); integration runs would dilute that loop for
+no commit-level benefit — driver / image regressions surface on a
+day-scale, not a commit-scale.
+
+### 3. Phased backend rollout
+
+The first cut ships with:
+
+- **Postgres 16** — `postgres:16-alpine`.
+- **MySQL 8.4** — `mysql:8.4` (LTS).
+
+Deferred to follow-up PRs, each with its own job block:
+
+- **SQL Server 2022** — the image is public but the service health-
+  check needs a different pattern (SA password + Developer edition
+  accepts EULA at boot).
+- **Oracle XE 21c** — boots in ~40 s with the `slim-faststart`
+  image, but the pluggable-database lifecycle needs an explicit
+  wait-for-ready probe beyond a simple port check.
+- **Kafka 7.7.1 + ZooKeeper** — two-service composition; needs a
+  topic-create step in the job.
+- **Hadoop / Impala bigdata stack** — unmaintained upstream images
+  (ADR-0029 follow-up with migration plan first).
+
+Each deferred backend lands as its own PR so a single broken job
+does not hold up the others.
+
+### 4. Connection fixture is stable, not parameterised
+
+Integration tests already hard-code credentials (`pdi` / `pdi!123456`
+/ `test_pdi` / `localhost:<port>`) to match the docker-compose
+fixtures. The workflow `services:` block mirrors those values
+exactly. We do **not** introduce a per-environment YAML layer here —
+the existing fixture-hardcoded credentials are unambiguous and
+rotating them in a future PR is a single search-and-replace.
+
+### 5. No test-matrix explosion
+
+Each backend runs on **one** cell: Python 3.11 / ubuntu-latest /
+pinned image version. Integration tests validate the adapter
+against the backend, not the interpreter, so a per-Python-version
+matrix would be pure noise. When a driver bump needs retesting on a
+specific Python, we add a temporary matrix dimension on a follow-up
+PR and remove it when done.
+
+### 6. Failure policy
+
+- A nightly failure opens no automatic issue. Maintainers review
+  the run via the Actions tab on the day after.
+- A `workflow_dispatch` failure is expected to be investigated by
+  the maintainer who triggered it.
+- Consecutive nightly failures (two or more days) should be flagged
+  as a blocker in the next release cut per
+  [ADR-0024 §3.1](./0024-release-process.md).
+
+## Consequences
+
+### Positive
+
+- Adapter regressions caught on a day-scale instead of a
+  downstream-bug-report-scale.
+- The `[integrator]` extras (oracledb, confluent-kafka, pandas,
+  mysql-connector-python, pyodbc, psycopg2-binary) have real
+  exercise. [ADR-0025](./0025-dependabot-auto-merge-policy.md)
+  rule 2 (no auto-merge for integrator drivers) becomes a
+  *supervised* human review — nightly result is the supervisor.
+- The docker-compose fixtures under `tests/environments/` become
+  living infrastructure: if a fixture breaks, the workflow fails
+  the next day, and the fix lands before a developer hits it.
+- GitHub Actions minutes are free on public repos, so the scheduled
+  run is zero-cost.
+
+### Negative
+
+- Two extra workflow runs per day (currently — five once all
+  backends land). Even at zero cost, it's queue pressure on free
+  runners. Scheduled for 04:00 UTC to dodge peak.
+- Flaky image boots (notably Oracle's occasional slow first-start)
+  will produce false negatives some mornings. Maintainers must
+  distinguish "real" failures from "re-run it and it passes".
+- New backends have to be onboarded twice: docker-compose fixture
+  **and** a job in this workflow. Small duplication of effort,
+  acceptable for the gain.
+
+### Neutral
+
+- The main CI workflow is unchanged — `.coveragerc`'s omit list
+  for `pdip/integrator/connection/types/**` stays in place because
+  adapter coverage lives in a separate run.
+
+## Alternatives considered
+
+### Option A — Run integration tests on every push
+
+- **Pro:** Zero latency on adapter regressions.
+- **Con:** Each integration run is 3–5 min per backend; a full set
+  would stretch the 2-min unit feedback loop to 15–20 min. The
+  point of [ADR-0018](./0018-testing-strategy.md)'s pyramid is that
+  fast tests gate development; breaking that trade-off for an
+  edge-case regression-surface is not worth it.
+- **Why rejected:** Nightly schedule + on-demand dispatch gives us
+  the regression signal without the feedback-loop cost.
+
+### Option B — Run integration tests in a nightly cron external to GitHub Actions
+
+- **Pro:** Avoids GitHub Actions queue-pressure issues.
+- **Con:** Adds an external piece of infrastructure to operate
+  (cron host, secret management, result publication). For a small
+  framework with public repos that get free Actions minutes, the
+  cost is all overhead.
+- **Why rejected:** Actions is the lowest-friction option.
+
+### Option C — Testcontainers instead of ``services:``
+
+- **Pro:** Same fixture running both in local test runs and in CI —
+  the test code itself spins up the container.
+- **Con:** Adds a Python dependency (`testcontainers`) and couples
+  local-dev tests to a Docker daemon even when the developer's
+  workflow is unit-only. The existing docker-compose files serve
+  local dev cleanly; `services:` serves CI cleanly; the two don't
+  need to be unified.
+- **Why rejected:** No new runtime dep for a problem we already have
+  two good solutions to.
+
+## Follow-ups
+
+- Add **MSSQL 2022** job (separate PR; needs `ACCEPT_EULA=Y` and a
+  service-health probe that works with SA login).
+- Add **Oracle XE 21c** job (separate PR; needs a readiness probe
+  that waits for the pluggable database, not just the listener).
+- Add **Kafka 7.7.1 + ZooKeeper** job (two-service composition,
+  topic-create step).
+- Consider migrating the Hadoop / Impala bigdata fixtures to
+  maintained images before adding their integration-test jobs.
+- If failures pile up, introduce a lightweight "open an issue on
+  two consecutive red nights" step using
+  `JasonEtco/create-an-issue` or similar.
+
+## References
+
+- [`.github/workflows/integration-tests.yml`](../../../.github/workflows/integration-tests.yml)
+- [`tests/environments/README.md`](../../../tests/environments/README.md)
+- ADR-0018 — Testing strategy (pyramid, deferred integration exec).
+- ADR-0023 §1 — Coverage omit list for adapter paths.
+- ADR-0024 §3.1 — Release cut requires green CI matrix.
+- ADR-0025 — Dependabot auto-merge policy (integrator drivers excluded).

--- a/docs/governance/adr/README.md
+++ b/docs/governance/adr/README.md
@@ -36,6 +36,7 @@ shapes how the framework is built and used. See the parent
 | [0026](./0026-test-quality-rules.md) | Test quality rules | Accepted | testing, ci, quality |
 | [0027](./0027-tdd-with-diff-coverage.md) | Test-first development (TDD) with diff-coverage enforcement | Accepted | testing, ci, quality, process |
 | [0028](./0028-raise-python-floor-to-3-10.md) | Raise `python_requires` floor from 3.9 to 3.10 | Accepted | packaging, compatibility, python, ci |
+| [0029](./0029-integration-tests-in-ci.md) | Integration tests run nightly in CI | Accepted | testing, ci, quality, integration |
 
 ## Status legend
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,3 +80,4 @@ nav:
           - ADR-0026 Test quality rules: governance/adr/0026-test-quality-rules.md
           - ADR-0027 TDD with diff-coverage: governance/adr/0027-tdd-with-diff-coverage.md
           - ADR-0028 Raise Python floor to 3.10: governance/adr/0028-raise-python-floor-to-3-10.md
+          - ADR-0029 Integration tests in CI: governance/adr/0029-integration-tests-in-ci.md


### PR DESCRIPTION
## Summary

Closes the longstanding gap from ADR-0018: `tests/integrationtests/` has existed since 0.7.0 but nothing in CI has ever run it. Adapter code under `pdip/integrator/connection/types/{sql,bigdata,webservice}/` is **excluded** from unit coverage (ADR-0023 §1) and had **no CI equivalent** until now. Driver bumps that broke an adapter landed to main invisibly.

This PR introduces `.github/workflows/integration-tests.yml` — a scheduled workflow that boots real database containers as GitHub Actions `services:` and runs the matching test modules against them.

## What the first cut includes

| Backend | Image | Test path | Health probe |
|---|---|---|---|
| **Postgres 16** | `postgres:16-alpine` (same pin as `tests/environments/postgresql/`) | `tests/integrationtests/integrator/integration/sql/postgresql/` | `pg_isready` |
| **MySQL 8.4** | `mysql:8.4` (same pin as `tests/environments/mysql/`) | `tests/integrationtests/integrator/integration/sql/mysql/` | `mysqladmin ping` |

Port, credentials, and database name all match the existing hardcoded test values (`pdi / pdi!123456 / test_pdi`, `localhost:5434` for Postgres, `localhost:3306` for MySQL). Postgres job also runs a `CREATE SCHEMA IF NOT EXISTS test_pdi` preflight — `POSTGRES_DB` creates the database, tests expect a same-named schema inside it.

Every action pinned to SHA per the PR #95 contract (`actions/checkout`, `actions/setup-python` — pulled forward from `main`).

## Triggers

| Trigger | When |
|---|---|
| `workflow_dispatch` | Any maintainer, Actions tab |
| `schedule: cron: "0 4 * * *"` | Daily at 04:00 UTC |

**Not** on `push` / `pull_request`. The main CI loop stays sub-2-min. See ADR-0029 for the rationale (regressions surface on a day-scale, not a commit-scale; flaky image-boot timing would produce noise on PRs).

## Deferred to follow-up PRs

Each lands as its own PR so one broken job doesn't hold up the others:

- **SQL Server 2022** — needs `ACCEPT_EULA=Y` + SA-login health probe pattern.
- **Oracle XE 21c** — needs a pluggable-database readiness probe beyond simple port check (~40 s on `slim-faststart`).
- **Kafka 7.7.1 + ZooKeeper** — two-service composition + topic-create step.
- **Hadoop / Impala** — migrate to maintained images **before** adding their integration jobs.

## Why ADR-0029

Written because "why nightly, not per-push" and "why these two backends first" are architecturally meaningful questions future contributors will ask. Failure policy (no automatic issue-creation; two consecutive red nights is a release blocker) is spelled out. Alternatives (push-triggered, external cron, Testcontainers) considered and rejected with reasons.

## Test plan

- [x] Workflow YAML parses (no syntax errors)
- [x] SHA-pinned actions match the SHAs in the main CI workflow
- [x] Postgres schema preflight is idempotent (`CREATE SCHEMA IF NOT EXISTS`)
- [x] Credentials / ports in `services:` match hardcoded test values
- [ ] First scheduled run executes tonight at 04:00 UTC, or any maintainer can trigger manually
- [ ] First manual `workflow_dispatch` run has passed (expected: maintainer triggers post-merge)
- [ ] First run may fail on schema-creation or driver-compat edge cases — follow-up PR adjusts

## Files changed

- `.github/workflows/integration-tests.yml` — new, 132 lines.
- `docs/governance/adr/0029-integration-tests-in-ci.md` — new ADR, cross-referenced from README + mkdocs nav.
- `docs/governance/adr/README.md`, `mkdocs.yml` — index entries for ADR-0029.
- `CHANGELOG.md` — `[Unreleased]` Added + Changed entries covering this PR and the SHA-pin / Docker-pin PRs that landed today.

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_