### PR TITLE
ci(integration): narrow pull_request self-test trigger for workflow/fixtures

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,18 @@ on:
     # Every day at 04:00 UTC. Deliberately late in the European evening
     # / early morning to avoid GitHub Actions queue pressure.
     - cron: "0 4 * * *"
+  # Self-test trigger: a PR that touches the workflow itself or the
+  # docker-compose fixtures it consumes runs immediately so the author
+  # sees it work against real backends before merging — without this,
+  # every workflow edit would be "merge and hope the next nightly is
+  # green". Scoped narrowly to only the integration-test-specific
+  # paths, so the main CI feedback loop stays unchanged. See
+  # ADR-0029 §2 for the "no per-push on unrelated files" rule.
+  pull_request:
+    paths:
+      - ".github/workflows/integration-tests.yml"
+      - "tests/environments/**"
+      - "tests/integrationtests/**"
 
 permissions:
   contents: read

--- a/docs/governance/adr/0029-integration-tests-in-ci.md
+++ b/docs/governance/adr/0029-integration-tests-in-ci.md
@@ -55,12 +55,14 @@ and runs the matching test module against it.
 |---|---|
 | `schedule: cron: "0 4 * * *"` | Daily at 04:00 UTC. |
 | `workflow_dispatch` | Any maintainer can run it on demand from the Actions tab. |
+| `pull_request` with narrow `paths:` | **Self-test only** — fires when a PR touches `.github/workflows/integration-tests.yml`, `tests/environments/**`, or `tests/integrationtests/**`. A workflow / fixture edit should not ship as "merge and hope the next nightly is green"; the PR author gets to see it work against real backends before review. |
 
-**Not** triggered on `push` or `pull_request`. The main CI workflow
-(`package-build-and-tests.yml`) stays focused on the fast unit-test
-path (< 2 min feedback); integration runs would dilute that loop for
-no commit-level benefit — driver / image regressions surface on a
-day-scale, not a commit-scale.
+**Not** triggered on unrelated `push` or `pull_request`. The main CI
+workflow (`package-build-and-tests.yml`) stays focused on the fast
+unit-test path (< 2 min feedback); running integration tests for
+every `pdip/` / test edit would dilute that loop for no commit-level
+benefit — driver / image regressions surface on a day-scale, not a
+commit-scale.
 
 ### 3. Phased backend rollout
 


### PR DESCRIPTION
## Summary

Adds a narrow `pull_request: paths:` trigger to the integration-tests workflow so PRs that touch the workflow itself or its fixtures see it run against real backends **before** merge, instead of "merge and hope the next nightly at 04:00 UTC is green".

Paths that fire the workflow:
- `.github/workflows/integration-tests.yml` itself
- `tests/environments/**` (docker-compose fixtures)
- `tests/integrationtests/**` (the test modules)

Everything else — any `pdip/**` change, unit-test edits, docs, ADRs — does **not** fire it. The main sub-2-min CI loop is unchanged.

ADR-0029 §2 Triggers table updated.

## Why now

This is also the first PR that actually exercises the newly-landed `integration-tests.yml` workflow end-to-end. The scheduled run hasn't fired yet (04:00 UTC tonight), and the MCP in this sandbox can't `workflow_dispatch`. Adding the `pull_request: paths:` trigger here gives an immediate end-to-end dry run **and** is a permanent-value addition (self-test on every future workflow/fixture edit).

## What you'll see in the check list

Two new jobs appear beside the normal unit-test matrix:
- `Postgres 16 / postgres` (boots `postgres:16-alpine` as a service, runs `tests/integrationtests/integrator/integration/sql/postgresql/`)
- `MySQL 8.4 / mysql` (boots `mysql:8.4` as a service, runs `tests/integrationtests/integrator/integration/sql/mysql/`)

Optimistic scenario: both green. Realistic scenario: one of them shows a driver / schema / timing edge case and we fix it in a follow-up commit on this branch.

## Test plan

- [x] Workflow YAML parses
- [x] `pull_request: paths:` limits the trigger to exactly the three self-test-relevant prefixes
- [ ] Integration-tests jobs appear in the check list on this PR
- [ ] Postgres job: `CREATE SCHEMA IF NOT EXISTS test_pdi` preflight succeeds, tests run
- [ ] MySQL job: `mysqladmin ping` health check passes, tests run

https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaFnfGopMrGNetnPSJdxyX)_