### PR TITLE
security(ci): add least-privilege permissions to package-build-and-tests workflow

### DIFF
--- a/.github/workflows/package-build-and-tests.yml
+++ b/.github/workflows/package-build-and-tests.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
     branches: [ development, main ]
 
+# Least-privilege GITHUB_TOKEN per CodeQL `actions/missing-workflow-permissions`.
+# This workflow only checks out the repo, runs tests, and uploads a coverage
+# artifact — none of which need write access. `actions/upload-artifact@v4+`
+# uses the run's own credentials and does not require elevated token scopes.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Setup ${{ matrix.python }} ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Closes CodeQL alert [#3](https://github.com/ahmetcagriakca/pdip/security/code-scanning/3) — `actions/missing-workflow-permissions` (Medium) on `.github/workflows/package-build-and-tests.yml:14`.

The workflow had no explicit `permissions:` block, so the `GITHUB_TOKEN` was inheriting the repository default scopes. Per CodeQL's recommendation, this PR adds an explicit least-privilege block at the workflow level:

```yaml
permissions:
  contents: read
```

The workflow only does three things — checkout, run tests/lint, upload a coverage artifact — and none need write access. `actions/upload-artifact@v4+` uploads to the run's own artifact storage using the run's credentials, no elevated token scopes required.

Brings this file in line with the other five workflows under `.github/workflows/`, which already declare explicit permissions blocks:

```
$ grep -l '^permissions:' .github/workflows/*.yml
.github/workflows/dependabot-auto-merge.yml
.github/workflows/docs-deploy.yml
.github/workflows/integration-tests.yml
.github/workflows/python-upload-package.yml
.github/workflows/python-upload-test-package.yml
```

After merge, alert #3 should auto-close on the next CodeQL run against `main`.

## Test plan

- [ ] CI matrix (5 Python × 3 OS = 15 cells) stays green — `contents: read` is sufficient for `actions/checkout`, `actions/setup-python`, `pip install`, `coverage run`, `coverage xml`, `diff-cover`, and `actions/upload-artifact`.
- [ ] CodeQL re-scan after merge resolves alert #3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFRfygucKKrdUjzdz3iwbn)_