### PR TITLE
docs(handoff): refresh after MSSQL job + ADR-0030 + Kafka scaffold landed

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -18,7 +18,7 @@
 | Diff coverage | **100 %** of changed `pdip/` lines vs `main` | [ADR-0027](governance/adr/0027-tdd-with-diff-coverage.md) |
 | Python floor | **3.10** (3.9 EOL, ADR-0028 supersedes ADR-0020) | [ADR-0028](governance/adr/0028-raise-python-floor-to-3-10.md) |
 | Unit-test CI matrix | Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 × macOS / Windows / Ubuntu | [`.github/workflows/package-build-and-tests.yml`](../.github/workflows/package-build-and-tests.yml) |
-| Integration CI | Nightly 04:00 UTC + `workflow_dispatch` + workflow self-test PR trigger; runs Postgres 16, MySQL 8.4, Oracle XE 21c | [`.github/workflows/integration-tests.yml`](../.github/workflows/integration-tests.yml), [ADR-0029](governance/adr/0029-integration-tests-in-ci.md) |
+| Integration CI | Nightly 04:00 UTC + `workflow_dispatch` + workflow self-test PR trigger; runs Postgres 16, MySQL 8.4, Oracle XE 21c, **SQL Server 2022** | [`.github/workflows/integration-tests.yml`](../.github/workflows/integration-tests.yml), [ADR-0029](governance/adr/0029-integration-tests-in-ci.md) |
 | Pre-commit | `pre-commit install` runs the 6 ADR-0026/0027 §5 quality rules + blocking flake8 in ~300 ms | [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) |
 
 ## 2. Open PRs
@@ -42,9 +42,10 @@ of this file. Most `claude/*` branches on the remote are post-merge
 artifacts from squash-merged PRs — safe to ignore unless a name below is
 listed. **Reserved (not yet pushed):**
 
-- `claude/integration-tests-adaptive-schedule` — reserved for the ADR-0029
-  §6 follow-up (open an issue on two consecutive red nights). No commits
-  yet; create when picking the work up.
+- No active reserved branches at the moment. (The previously-reserved
+  `claude/integration-tests-adaptive-schedule` name is no longer pinned
+  here — see §4 "Adaptive nightly-failure issue" for why that work is
+  deferred against ADR-0029 §6's current "manual review" policy.)
 
 If you find a `claude/*` branch not listed here and not associated with an
 open PR, it is almost certainly stale — confirm with `git log
@@ -58,11 +59,11 @@ ADR if the answer changed.
 | Topic | Status | Pointer |
 |---|---|---|
 | `oracledb` 4.x adoption | `setup.py` now allows `oracledb>=2,<4`, so 3.x lands automatically; 4.x is not yet released upstream. The adapter only uses `makedsn` + `connect` (DB-API 2.0 surface), which has been stable across the 2.x/3.x line per [ADR-0021](governance/adr/0021-cx-oracle-to-python-oracledb.md). | When Dependabot opens a `<4 → <5` PR, re-run the same surface audit before bumping the upper bound. |
-| MSSQL 2022 nightly job | Listed under [ADR-0029 Follow-ups](governance/adr/0029-integration-tests-in-ci.md). Needs `ACCEPT_EULA=Y` and an SA-login health probe. | Separate PR; image already pinned in `tests/environments/mssql/`. |
-| Kafka 7.7.1 + ZooKeeper nightly job | [ADR-0029 Follow-ups](governance/adr/0029-integration-tests-in-ci.md). Two-service composition + topic-create step. | Separate PR; image already pinned. |
-| Hadoop / Impala fixtures | Marked `# unmaintained` in `tests/environments/`. ADR-0029 explicitly defers their integration-test job until images are migrated. | Migration plan ADR first, then job. |
+| Kafka nightly integration job | Smoke-test scaffold for `KafkaConnector` lives at `tests/integrationtests/integrator/connection/queue/kafka/` and runs locally against `tests/environments/kafka/docker-compose.yml`. The matching nightly CI job did *not* land — four image / config combinations failed (cp-kafka + cp-zookeeper, apache/kafka 3.7 KRaft, bitnami/kafka 3.7 KRaft, plus a debug log-dump variant) and the Actions logs are auth-walled to non-collaborators. | A maintainer with collaborator access reads the actual job log to identify the broker-exit cause, then opens one targeted fix PR adding the `kafka:` job to `.github/workflows/integration-tests.yml`. |
+| Hadoop / Impala fixtures + bigdata nightly | [ADR-0030](governance/adr/0030-hadoop-impala-fixture-migration.md) records the three-stage migration plan (Status: Proposed). Stage 1 — collapse to a single `apache/impala` fixture + delete `tests/environments/hadoop/`. Stage 2 — re-introduce `apache/kudu:1.17.0` only if existing tests reach Kudu code paths. Stage 3 — wire the `impala:` nightly job. | Stage 1 PR carries the audit (does `apache/impala:4.x` boot inside Actions `services:` 15-min timeout?). |
+| Adaptive nightly-failure issue (auto-open issue on two red nights) | [ADR-0029 §6](governance/adr/0029-integration-tests-in-ci.md) currently mandates *manual* review via the Actions tab; the auto-open behaviour is listed under §Follow-ups with the explicit pre-condition "if failures pile up". Today there is no failure backlog to justify it. | When two consecutive nightly failures are observed without a same-day fix landing, open ADR-0031 superseding §6. |
 | `examples/etl` + pub/sub observer demo | Listed in [`examples/README.md`](../examples/README.md) as planned follow-ups to `examples/crud_api`. | None — pick up when the next end-to-end story needs an executable reference. |
-| Async / OpenTelemetry / 1.0 cut | No ADR drafted. Mentioned as long-horizon items in conversation; not on any milestone. | Open as ADR-0030+ when an actual driver appears. |
+| Async / OpenTelemetry / 1.0 cut | No ADR drafted. Mentioned as long-horizon items in conversation; not on any milestone. | Open as ADR-0031+ when an actual driver appears. |
 
 ## 5. Read this first
 
@@ -84,7 +85,8 @@ rest.
 
 ---
 
-*Last updated 2026-04-25 on `claude/handoff-clear-merged-prs` (clearing
-the three merged Dependabot rows). When you change anything above, bump
-this line with the date and the branch name so the next reader knows the
-freshness window at a glance.*
+*Last updated 2026-04-25 on `claude/handoff-update-batch-2` (after the
+MSSQL nightly job, ADR-0030 Hadoop migration plan, and Kafka test
+scaffold landed; Kafka nightly job and adaptive-schedule deferred).
+When you change anything above, bump this line with the date and the
+branch name so the next reader knows the freshness window at a glance.*


### PR DESCRIPTION
## Summary

Refreshes `docs/handoff.md` to reflect the four PRs that landed in this session:

- **#105 — MSSQL 2022 nightly job.** §1 backend list now mentions SQL Server 2022. §4 row removed (no longer deferred).
- **#106 — ADR-0030 Hadoop / Impala / Kudu migration plan (Proposed).** §4 row rewritten to point at the new ADR with its three-stage plan summary.
- **#107 — Kafka integration test scaffold.** §4 row reframed: scaffold landed, nightly CI job is now the deferred piece. Includes an honest note about the four-attempt failure history (cp-kafka + cp-zookeeper, apache/kafka KRaft, bitnami/kafka KRaft, debug log-dump variant) and the auth-wall on Actions logs that blocked further iteration.
- **Adaptive-schedule deferral made explicit.** New §4 row grounds the deferral in ADR-0029 §6's current "manual review" policy and gives a concrete trigger for the future ADR-0031 that would supersede it: *two consecutive nightly failures without a same-day fix*.

Also:
- §3 stops pinning a reserved branch name for the adaptive-schedule follow-up (avoids handoff cruft for work that's not actively queued).
- Footer freshness stamp bumped with this branch name and a one-sentence summary of what changed.

## Test plan

- [ ] Render `docs/handoff.md` in the PR preview.
- [ ] Every relative link still resolves (ADR-0021 / ADR-0029 / ADR-0030 / `examples/README.md`).
- [ ] Spot-check §1 backend list against `.github/workflows/integration-tests.yml` after MSSQL merge.
- [ ] No source / fixture / workflow changes — pure doc; main matrix passes unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFRfygucKKrdUjzdz3iwbn)_