### PR TITLE
feat(ci): ADR-0031 + nightly-failure-tracker workflow (auto-open issue on 2 red nights)

### DIFF
--- a/.github/workflows/nightly-failure-tracker.yml
+++ b/.github/workflows/nightly-failure-tracker.yml
@@ -1,0 +1,182 @@
+# Auto-open / update / close a tracking issue when the nightly
+# integration workflow fails on two consecutive nights, then closes
+# it once a subsequent nightly is green again.
+#
+# Policy source: docs/governance/adr/0031-adaptive-nightly-failure-issue.md
+# (ADR-0031 — supersedes ADR-0029 §6 "no automatic issue" rule for
+# the two-consecutive-failure case only).
+#
+# Trigger: ``workflow_run`` for ``Integration tests (nightly)``,
+# completed event, ``main`` branch only. ``workflow_dispatch``
+# triggered runs are excluded — those are maintainer-initiated and
+# investigation lives with whoever pressed the button.
+#
+# Single open issue at a time, labelled ``nightly-red``. A second
+# consecutive failure appends a comment instead of opening a
+# duplicate; a green run after the issue exists closes it
+# automatically.
+
+name: Nightly failure tracker
+
+on:
+  workflow_run:
+    workflows: ["Integration tests (nightly)"]
+    types: [completed]
+    branches: [main]
+
+# Minimum needed to create / comment on / close issues. No write
+# access to code or releases. Sits below the ``contents: read``
+# default the rest of the repo's workflows declare per PR #104.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  track:
+    name: Open / update / close ``nightly-red`` issue
+    runs-on: ubuntu-latest
+    # Only react to scheduled cron runs; ignore manual dispatches.
+    # ``workflow_dispatch`` events have ``event == 'workflow_dispatch'``;
+    # the nightly cron arrives as ``schedule``. Pull-request self-test
+    # runs of the source workflow are also excluded so a PR fixing
+    # the workflow doesn't false-fire the tracker.
+    if: github.event.workflow_run.event == 'schedule'
+    timeout-minutes: 5
+
+    steps:
+      - name: Decide trigger condition (two consecutive failures, or recovery)
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THIS_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          THIS_RUN_ID: ${{ github.event.workflow_run.id }}
+          THIS_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+        run: |
+          set -euo pipefail
+
+          # Look at the *previous* completed scheduled run on main for
+          # this workflow. We need both runs' conclusions to decide
+          # whether to open / update / close the tracker issue.
+          previous_conclusion="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs?branch=main&event=schedule&status=completed&per_page=2" \
+              --jq '.workflow_runs[1].conclusion // "none"'
+          )"
+
+          echo "this_conclusion=${THIS_RUN_CONCLUSION}" >> "$GITHUB_OUTPUT"
+          echo "previous_conclusion=${previous_conclusion}" >> "$GITHUB_OUTPUT"
+          echo "this_run_url=${THIS_RUN_URL}" >> "$GITHUB_OUTPUT"
+          echo "this_run_id=${THIS_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+          # ``failure`` here means at least one job in the matrix
+          # ended with conclusion=failure. ``cancelled`` and
+          # ``timed_out`` are not counted toward the two-failure
+          # trigger — those are infrastructure issues, not regressions.
+          if [[ "${THIS_RUN_CONCLUSION}" == "failure" && "${previous_conclusion}" == "failure" ]]; then
+            echo "action=open_or_comment" >> "$GITHUB_OUTPUT"
+          elif [[ "${THIS_RUN_CONCLUSION}" == "success" ]]; then
+            echo "action=close_if_open" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=skip" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find the open ``nightly-red`` issue, if any
+        id: find
+        if: steps.decide.outputs.action != 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Single-issue-per-outage: search for an open issue that
+          # already carries the label. We accept the empty list case
+          # (no open issue yet) and the one-or-more case (use the
+          # first / oldest one as the tracker).
+          existing="$(
+            gh issue list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --label nightly-red \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+          echo "existing_number=${existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or comment on the tracker issue
+        if: steps.decide.outputs.action == 'open_or_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          run_url="${{ steps.decide.outputs.this_run_url }}"
+          run_id="${{ steps.decide.outputs.this_run_id }}"
+
+          # Pull the failing job names so the issue body / comment
+          # names which backend(s) regressed instead of just the run
+          # URL. ``--jq`` filters to failure conclusions; the
+          # tracker is only interested in the matrix cells that
+          # actually broke.
+          failing_jobs="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+              --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")'
+          )"
+
+          if [[ -z "${{ steps.find.outputs.existing_number }}" ]]; then
+            # No open tracker — open a fresh one. The label is
+            # created on first use; no maintainer setup required.
+            gh label create nightly-red \
+              --color "d73a4a" \
+              --description "Two or more consecutive nightly integration failures (ADR-0031)" \
+              --force \
+              --repo "${GITHUB_REPOSITORY}" || true
+
+            gh issue create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --label nightly-red \
+              --title "Nightly integration tests have failed two nights in a row" \
+              --body "$(cat <<EOF
+Two consecutive scheduled runs of \`Integration tests (nightly)\` on \`main\` ended with \`conclusion: failure\`. Per [ADR-0031](docs/governance/adr/0031-adaptive-nightly-failure-issue.md) this issue is opened automatically as a single tracker for the outage.
+
+**Latest failed run:** ${run_url}
+**Failing job(s):** ${failing_jobs:-(none reported by API)}
+
+The tracker stays open until a subsequent scheduled nightly is green; the workflow will then comment "resolved" and close the issue automatically. A second consecutive failure during the outage adds a comment here instead of opening a duplicate.
+
+If a maintainer fixes the underlying regression by hand, please leave the issue open — the auto-close will still trigger on the first green nightly so the lifecycle stays consistent.
+
+References: [ADR-0029](docs/governance/adr/0029-integration-tests-in-ci.md), [ADR-0031](docs/governance/adr/0031-adaptive-nightly-failure-issue.md).
+EOF
+)"
+          else
+            # Existing tracker — append a comment with this run's
+            # URL and failing jobs. Do not edit the body; the
+            # original "started on day N" framing stays intact.
+            gh issue comment "${{ steps.find.outputs.existing_number }}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --body "$(cat <<EOF
+Another consecutive failure tonight.
+
+**Run:** ${run_url}
+**Failing job(s):** ${failing_jobs:-(none reported by API)}
+EOF
+)"
+          fi
+
+      - name: Close the tracker issue if a green nightly arrived
+        if: steps.decide.outputs.action == 'close_if_open' && steps.find.outputs.existing_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          run_url="${{ steps.decide.outputs.this_run_url }}"
+
+          # Resolve and close in one shot. ``gh issue close``'s
+          # ``--comment`` flag posts the comment then closes — same
+          # API as the GitHub UI's "close with comment" affordance.
+          gh issue close "${{ steps.find.outputs.existing_number }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --reason completed \
+            --comment "Resolved by ${run_url} — closing automatically per ADR-0031."

--- a/docs/governance/adr/0031-adaptive-nightly-failure-issue.md
+++ b/docs/governance/adr/0031-adaptive-nightly-failure-issue.md
@@ -1,0 +1,229 @@
+# ADR-0031: Auto-open a tracking issue on two consecutive nightly integration failures
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Deciders:** pdip maintainers
+- **Tags:** testing, ci, automation, governance
+- **Supersedes:** [ADR-0029](./0029-integration-tests-in-ci.md) §6 in
+  part — the "no automatic issue" rule is replaced for the
+  two-consecutive-failure case; the rest of §6 (manual review for a
+  single failure, release-cut blocker for ≥ 2) stays.
+
+## Context
+
+ADR-0029 §6 set the failure policy when the nightly integration
+workflow first landed:
+
+> A nightly failure opens no automatic issue. Maintainers review
+> the run via the Actions tab on the day after.
+> A `workflow_dispatch` failure is expected to be investigated by
+> the maintainer who triggered it.
+> Consecutive nightly failures (two or more days) should be flagged
+> as a blocker in the next release cut per ADR-0024 §3.1.
+
+That policy was conservative on purpose — the workflow had no track
+record, the maintainer pool is small, and noisy auto-issues for a
+flaky single-night failure (e.g. a Docker Hub mirror hiccup) would
+have produced more friction than signal. ADR-0029's `## Follow-ups`
+list flagged the auto-issue idea as a *conditional* future change:
+
+> If failures pile up, introduce a lightweight "open an issue on
+> two consecutive red nights" step …
+
+The situation today:
+
+- The integration workflow has now run against four real backends
+  (Postgres 16, MySQL 8.4, Oracle XE 21c, SQL Server 2022 — see
+  PRs #98, #100, #105). The MSSQL and Oracle jobs each took two
+  iterations to land; the historical patch rate on this workflow is
+  not zero, and a future driver bump could land a regression that
+  the daily-Actions-tab check misses on the day it arrives.
+- The maintainer pool is still small. A nightly failure that
+  surfaces only via an Actions-tab notification depends on at least
+  one maintainer remembering to look the next morning.
+- We now have a code-scanning alert path (PR #104 added explicit
+  workflow `permissions:`), and the GitHub MCP integration in this
+  repository's tooling demonstrates that issue create / update is a
+  routine, low-risk operation.
+
+The cost of leaving the gap is bounded but real: a failing nightly
+that goes unnoticed for several days delays the time-to-detect for
+any downstream regression and erodes the value ADR-0029 set out to
+deliver.
+
+## Decision
+
+We adopt a **two-consecutive-failure trigger** for an automatically
+opened tracking issue:
+
+### 1. Trigger condition
+
+A new workflow opens (or appends to) a single tracking issue when
+**both** of the following hold:
+
+1. The most recent completed run of the
+   `Integration tests (nightly)` workflow on the default branch
+   ended with `conclusion: failure` for *at least one* job in the
+   matrix (not just `cancelled` / `timed_out`).
+2. The run immediately before it on the default branch ended the
+   same way.
+
+`workflow_dispatch` runs are excluded from the count — they are
+maintainer-initiated and ADR-0029 §6 already places investigation
+on the triggering maintainer.
+
+### 2. Issue shape
+
+A single open issue tracks the outage; a second consecutive failure
+does **not** open a second issue. The workflow searches for an open
+issue labelled `nightly-red` and updates it (adds a comment with the
+new run URL and the names of the failing jobs) instead of creating a
+duplicate.
+
+When all backends pass on a subsequent nightly run, the workflow
+adds a "resolved" comment and closes the issue automatically. The
+next two-consecutive-failure window opens a fresh issue.
+
+The issue body documents the affected backends, the run URLs, and a
+link back to this ADR for context. The `nightly-red` label is
+created on first use; no maintainer setup is required.
+
+### 3. Permissions
+
+The new workflow declares `permissions: { issues: write,
+contents: read }` at the workflow level — the minimum needed to
+create / comment on / close issues, with no write access to code
+or releases. This sits below the per-job permissions floor pdip
+adopted in PR #104 for `package-build-and-tests.yml`.
+
+### 4. Implementation outline
+
+A new file `.github/workflows/nightly-failure-tracker.yml`:
+
+- Triggers on `workflow_run` for the
+  `Integration tests (nightly)` workflow, completed event only,
+  filtered to `branches: [main]`.
+- One job that:
+  1. Reads the *previous* workflow run on the same workflow + branch
+     via `gh api repos/{owner}/{repo}/actions/workflows/<id>/runs`.
+  2. Computes the trigger condition from §1.
+  3. If true, calls `gh issue list --label nightly-red` to find an
+     open tracker issue; if absent, calls `gh issue create`; if
+     present, calls `gh issue comment`.
+  4. If the *current* run is green and an open `nightly-red` issue
+     exists, calls `gh issue close` after a confirming comment.
+
+The workflow uses only `gh` calls available with the default
+`GITHUB_TOKEN` — no PAT, no third-party action.
+
+## Consequences
+
+### Positive
+
+- Time-to-detect for nightly regressions shrinks from "next time a
+  maintainer remembers to look" to "the morning of the second
+  failed nightly". For a regression introduced on day N, the issue
+  fires day N+2 instead of an indefinite manual-review window.
+- The single-issue-per-outage shape keeps the issue tracker quiet —
+  a sustained outage produces one issue with comments, not a daily
+  flood.
+- The auto-close ties the lifecycle of the tracker to the workflow
+  result, so a stale "nightly broken" issue cannot persist past the
+  fix.
+- Squeezes the gap that motivated ADR-0029's `## Follow-ups` bullet
+  without taking ADR-0029 §6's other guarantees off the table
+  (single-night failure stays manual; release-cut blocker stays).
+
+### Negative
+
+- **One more workflow file to maintain.** The tracker is small
+  (~80 lines of YAML + a couple of `gh` commands) but it is real
+  code that can rot if the GitHub Actions API changes.
+- **Issue noise during a flaky window.** If the workflow itself is
+  flaky (e.g. Docker Hub rate-limiting that resolves on retry), the
+  tracker may open and close issues across consecutive nights. The
+  trigger requires *two* failures to dampen this, and the
+  single-issue shape limits the comment-spam blast radius.
+- **`issues: write` permission scope.** Larger than the
+  `contents: read` baseline most workflows in this repo run with.
+  Bounded by sitting on its own workflow (no code-touching steps)
+  and explicit declaration; CodeQL's
+  `actions/missing-workflow-permissions` rule that PR #104 fixed
+  stays satisfied.
+
+### Neutral
+
+- ADR-0024 §3.1's "two-or-more consecutive failures block the next
+  release cut" provision is unchanged. The automated issue is a
+  *signal* for that policy, not a replacement.
+- Maintainer day-after review remains the right channel for a
+  *single* nightly failure; this ADR explicitly does not auto-open
+  an issue then.
+
+## Alternatives considered
+
+### Option A — Keep ADR-0029 §6 verbatim ("no automatic issue, ever")
+
+- **Pro:** Zero new workflow code, no permission expansion.
+- **Con:** Leaves the time-to-detect gap. The longer the workflow
+  runs without auto-tracking, the more likely a regression slips
+  past two consecutive nights without anyone noticing.
+- **Why rejected:** The original §6 wording explicitly anticipated
+  this revision via the `## Follow-ups` "if failures pile up"
+  bullet. We are not changing the spirit of §6, just acting on the
+  follow-up trigger condition it pre-described.
+
+### Option B — Open an issue on the *first* failure
+
+- **Pro:** Minimal latency; first failure surfaces immediately.
+- **Con:** Noisy. A single Docker Hub blip, runner image
+  regression, or upstream image GC creates a fresh issue every time.
+  Maintainers learn to ignore the channel, defeating the purpose.
+- **Why rejected:** ADR-0029 §6 already names the single-failure
+  case as "review via the Actions tab" specifically to avoid this
+  noise level. The two-failure threshold preserves that intent.
+
+### Option C — Slack / email webhook instead of an issue
+
+- **Pro:** Doesn't expand workflow `permissions:`; relies on
+  external delivery.
+- **Con:** pdip is a public open-source project without a shared
+  Slack workspace or maintainer mailing list. The right surface for
+  contributors to discover *and* discuss a regression is the issue
+  tracker, where the conversation can also be referenced from a
+  follow-up release-cut decision (ADR-0024 §3.1).
+- **Why rejected:** Wrong channel for an open-source workflow.
+
+### Option D — Schedule-only check (cron at 06:00 UTC)
+
+- **Pro:** Simpler trigger; no `workflow_run` dependency.
+- **Con:** Wastes a runner if no nightly happened (the cron in
+  ADR-0029 §2 fires at 04:00 UTC, but failures or `workflow_dispatch`
+  blow that schedule). The `workflow_run` trigger reacts to the
+  *actual* workflow result, regardless of when it ran.
+- **Why rejected:** Less accurate for the same maintenance cost.
+
+## Follow-ups
+
+- **Implementation PR** — adds
+  `.github/workflows/nightly-failure-tracker.yml` and a smoke test
+  (a manual `workflow_dispatch` against a known-failed run id). The
+  PR moves this ADR's status to `Accepted — Implemented YYYY-MM-DD
+  (PR #N)`, matching the ADR-0021 / ADR-0022 implementation-stamp
+  convention.
+- **ADR-0029 cross-reference** — once this lands, ADR-0029 §6 gains
+  a one-line note pointing at this ADR for the
+  two-consecutive-failure path.
+- **Tuning window** — revisit after the first three months of
+  nightly runs. If false-positive issue opens fire more than once
+  per month, raise the threshold to three consecutive failures or
+  add a same-day-fix exception (don't open if a maintainer-merged
+  PR landed between the two failures).
+
+## References
+
+- ADR-0029 §6 / §Follow-ups: `docs/governance/adr/0029-integration-tests-in-ci.md`
+- ADR-0024 §3.1: `docs/governance/adr/0024-release-process.md`
+- PR #104 — workflow permissions baseline pdip adopted earlier in 2026-04
+- GitHub Actions `workflow_run` event: <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run>
+- GitHub `gh issue` CLI: <https://cli.github.com/manual/gh_issue>

--- a/docs/governance/adr/README.md
+++ b/docs/governance/adr/README.md
@@ -38,6 +38,7 @@ shapes how the framework is built and used. See the parent
 | [0028](./0028-raise-python-floor-to-3-10.md) | Raise `python_requires` floor from 3.9 to 3.10 | Accepted | packaging, compatibility, python, ci |
 | [0029](./0029-integration-tests-in-ci.md) | Integration tests run nightly in CI | Accepted | testing, ci, quality, integration |
 | [0030](./0030-hadoop-impala-fixture-migration.md) | Migrate the Hadoop / Impala / Kudu fixtures off unmaintained images | Proposed | testing, ci, fixtures, bigdata |
+| [0031](./0031-adaptive-nightly-failure-issue.md) | Auto-open a tracking issue on two consecutive nightly integration failures | Proposed | testing, ci, automation, governance |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

Closes the adaptive-schedule deferred decision in [`docs/handoff.md`](https://github.com/ahmetcagriakca/pdip/blob/main/docs/handoff.md) §4 — a tracker workflow now auto-opens a single GitHub issue when the nightly integration tests fail two scheduled runs in a row, and auto-closes it when a subsequent run is green.

### What lands

- **ADR-0031 (Proposed)** — supersedes [ADR-0029](https://github.com/ahmetcagriakca/pdip/blob/main/docs/governance/adr/0029-integration-tests-in-ci.md) §6's "no automatic issue, ever" rule for the **two-consecutive-failure case only**. Rest of §6 stays (single-night failure → manual review; ≥ 2 failures → release-cut blocker per ADR-0024 §3.1). The decision document lives at `docs/governance/adr/0031-adaptive-nightly-failure-issue.md`.
- **`.github/workflows/nightly-failure-tracker.yml`** — companion implementation, in the ADR-0026 / ADR-0027 "decision + first implementation in one PR" pattern. `workflow_run` trigger on the integration-tests workflow's completed `schedule` events.

### Mechanics

1. Reads the *previous* scheduled run's conclusion via `gh api` (filtered to `branch=main`, `event=schedule`, `status=completed`, `per_page=2`).
2. If both this run and the previous one ended in `failure`, finds an open issue labelled `nightly-red` (single-issue-per-outage shape) and either creates one or appends a comment with the run URL and failing-job names.
3. If this run ended in `success` and an open `nightly-red` issue exists, closes it with a "resolved by <run_url>" comment.

### Excluded from the trigger

- `workflow_dispatch` runs (maintainer-initiated; investigation lives with whoever pressed the button).
- Pull-request self-test runs of the source workflow (so a PR fixing the integration workflow doesn't false-fire the tracker).
- `cancelled` / `timed_out` conclusions — those are infrastructure issues, not regressions.

### Permissions

- `contents: read` + `issues: write`, declared at workflow level. Sits above the `contents: read` baseline PR #104 set for `package-build-and-tests.yml` but stays below write access to code or releases.
- `nightly-red` label is created on first use via `gh label create --force` — no maintainer setup required.

## Test plan

- [ ] CI matrix on this PR is green (workflow file is syntactically valid; mkdocs build doesn't break).
- [ ] CodeQL `actions/missing-workflow-permissions` rule stays satisfied (workflow declares explicit `permissions:` block).
- [ ] After merge, manually trigger the source `Integration tests (nightly)` workflow with `workflow_dispatch` and confirm the tracker workflow's `if:` gate skips it (event != schedule).
- [ ] First real activation will be observed when two scheduled nightlies fail in a row; the ADR's status moves to `Accepted — Implemented YYYY-MM-DD (PR #N)` when that activation produces or closes an issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFRfygucKKrdUjzdz3iwbn)_