### PR TITLE
docs(handoff): clear oracledb 4.x + done-rows from §4

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -58,12 +58,9 @@ ADR if the answer changed.
 
 | Topic | Status | Pointer |
 |---|---|---|
-| `oracledb` 4.x adoption | `setup.py` now allows `oracledb>=2,<4`, so 3.x lands automatically; 4.x is not yet released upstream. The adapter only uses `makedsn` + `connect` (DB-API 2.0 surface), which has been stable across the 2.x/3.x line per [ADR-0021](governance/adr/0021-cx-oracle-to-python-oracledb.md). | When Dependabot opens a `<4 → <5` PR, re-run the same surface audit before bumping the upper bound. |
 | Kafka nightly integration job | Smoke-test scaffold for `KafkaConnector` lives at `tests/integrationtests/integrator/connection/queue/kafka/` and runs locally against `tests/environments/kafka/docker-compose.yml`. The matching nightly CI job did *not* land — four image / config combinations failed (cp-kafka + cp-zookeeper, apache/kafka 3.7 KRaft, bitnami/kafka 3.7 KRaft, plus a debug log-dump variant) and the Actions logs are auth-walled to non-collaborators. | A maintainer with collaborator access reads the actual job log to identify the broker-exit cause, then opens one targeted fix PR adding the `kafka:` job to `.github/workflows/integration-tests.yml`. |
-| Hadoop / Impala fixtures + bigdata nightly | [ADR-0030](governance/adr/0030-hadoop-impala-fixture-migration.md) records the three-stage migration plan (Status: Proposed). Stage 1 — collapse to a single `apache/impala` fixture + delete `tests/environments/hadoop/`. Stage 2 — re-introduce `apache/kudu:1.17.0` only if existing tests reach Kudu code paths. Stage 3 — wire the `impala:` nightly job. | Stage 1 PR carries the audit (does `apache/impala:4.x` boot inside Actions `services:` 15-min timeout?). |
-| Adaptive nightly-failure issue (auto-open issue on two red nights) | [ADR-0029 §6](governance/adr/0029-integration-tests-in-ci.md) currently mandates *manual* review via the Actions tab; the auto-open behaviour is listed under §Follow-ups with the explicit pre-condition "if failures pile up". Today there is no failure backlog to justify it. | When two consecutive nightly failures are observed without a same-day fix landing, open ADR-0031 superseding §6. |
-| `examples/etl` + pub/sub observer demo | Listed in [`examples/README.md`](../examples/README.md) as planned follow-ups to `examples/crud_api`. | None — pick up when the next end-to-end story needs an executable reference. |
-| Async / OpenTelemetry / 1.0 cut | No ADR drafted. Mentioned as long-horizon items in conversation; not on any milestone. | Open as ADR-0031+ when an actual driver appears. |
+| Hadoop / Impala fixtures + bigdata nightly | [ADR-0030](governance/adr/0030-hadoop-impala-fixture-migration.md) (Status: Proposed). Stage 1's mechanical part landed in PR #110 (deleted `tests/environments/hadoop/`, updated environments README). Stage 1's substantive part (translate the upstream `apache/impala/docker/quickstart.yml` into a 5-service fixture: postgres + impala_quickstart_hms + statestored + catalogd + impalad_coord_exec) and Stage 3 (`impala:` nightly job) still pending. | Open one PR carrying the new compose + the workflow job; the integration-tests self-test trigger fires on the PR, so the Actions matrix validates the boot end-to-end. |
+| Async / OpenTelemetry / 1.0 cut | No ADR drafted. Mentioned as long-horizon items in conversation; not on any milestone. | Open as ADR-0032+ when an actual driver appears. |
 
 ## 5. Read this first
 
@@ -85,8 +82,10 @@ rest.
 
 ---
 
-*Last updated 2026-04-25 on `claude/handoff-update-batch-2` (after the
-MSSQL nightly job, ADR-0030 Hadoop migration plan, and Kafka test
-scaffold landed; Kafka nightly job and adaptive-schedule deferred).
-When you change anything above, bump this line with the date and the
-branch name so the next reader knows the freshness window at a glance.*
+*Last updated 2026-04-25 on `claude/handoff-clear-deferred-zero` (after
+PRs #110–#112: hadoop fixture deleted, ADR-0031 + nightly-failure-tracker
+workflow landed, examples/etl + pubsub_observer landed; oracledb 4.x and
+the now-implemented adaptive-schedule rows removed from §4 since they no
+longer reflect deferred work). When you change anything above, bump this
+line with the date and the branch name so the next reader knows the
+freshness window at a glance.*


### PR DESCRIPTION
## Summary

Clears deferred-decision rows from `docs/handoff.md` §4 that no longer represent actual deferred work after this session's PRs #110, #111, #112 landed.

| Row | Why removed / changed |
|---|---|
| `oracledb 4.x adoption` | Upstream `python-oracledb` is at 3.4.2 (2026-01); 4.x has not been released. The row was a no-op until upstream ships 4.x; Dependabot will surface the bump via the existing `<4 → <5` PR pattern when that happens. **Removed.** |
| Adaptive nightly-failure issue | Landed in PR #111 as ADR-0031 + `.github/workflows/nightly-failure-tracker.yml`. No longer deferred. **Removed.** |
| `examples/etl + pub/sub observer demo` | Landed in PR #112; both runnable examples present in `examples/`. **Removed.** |
| Hadoop / Impala fixtures + bigdata nightly | Stage 1's mechanical part landed in #110. Row reframed to reflect the actual remaining work (translate `apache/impala/docker/quickstart.yml` into a 5-service fixture + Stage 3 `impala:` nightly job, opened in one PR so the integration-tests self-test trigger validates end-to-end). |
| Async / OpenTelemetry / 1.0 cut | Placeholder ADR number bumped 0031+ → 0032+ now that 0031 is taken. |

The Kafka nightly integration job row stays — it's still genuinely blocked on someone with collaborator access reading the auth-walled job log.

Footer freshness stamp bumped with this branch name + one-sentence change summary.

## Test plan

- [ ] `docs/handoff.md` renders correctly in PR preview; §4 now lists three rows (Kafka, Hadoop/Impala, Async/OTel/1.0).
- [ ] All relative ADR / `examples/README.md` links still resolve.
- [ ] No source / fixture / workflow changes; pure doc PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFRfygucKKrdUjzdz3iwbn)_