### PR TITLE
chore(fixtures): translate apache/impala quickstart.yml into bigdata fixture (ADR-0030 Stage 1)

### DIFF
--- a/docs/governance/adr/0030-hadoop-impala-fixture-migration.md
+++ b/docs/governance/adr/0030-hadoop-impala-fixture-migration.md
@@ -1,8 +1,10 @@
 # ADR-0030: Migrate the Hadoop / Impala / Kudu fixtures off unmaintained images
 
-- **Status:** Proposed (revised 2026-04-25 after a Docker Hub audit
-  reframed Stage 1 — see *Decision §Stage 1* and the *Revision
-  history* footer)
+- **Status:** Proposed (revised 2026-04-25 twice — first after the
+  Docker Hub audit reframed Stage 1 as multi-component, then after
+  the Stage 1 fixture translation surfaced that Stage 3's intended
+  test target is currently a stub. See *Decision §Stage 1*,
+  *Decision §Stage 3*, and the *Revision history* footer.)
 - **Date:** 2026-04-25
 - **Deciders:** pdip maintainers
 - **Tags:** testing, ci, fixtures, bigdata
@@ -129,7 +131,7 @@ Kudu features are reached.
 
 ### Stage 3 — wire the bigdata nightly job
 
-With both fixtures pointing at maintained, version-pinned images,
+With the fixture pointing at maintained, version-pinned images,
 add an `impala:` job to `.github/workflows/integration-tests.yml`
 mirroring the `postgres:` / `mysql:` / `oracle:` / `mssql:`
 pattern. The runner installs the **Cloudera Impala ODBC driver**
@@ -137,6 +139,20 @@ pattern. The runner installs the **Cloudera Impala ODBC driver**
 Apache 4.x build), boots the compose-defined services as Actions
 `services:` containers, and runs
 `tests/integrationtests/integrator/integration/bigdata/impala/`.
+
+> **Stage 3 prerequisite — test code first.** During Stage 1
+> implementation we discovered that
+> `tests/integrationtests/integrator/integration/bigdata/impala/`
+> contains exactly two files (`test_integration_single_process.py`
+> and `test_integration_limit_off.py`) and **both are entirely
+> commented out** — the file content is `# from unittest import …`
+> top to bottom. Wiring a CI job today would `unittest discover`
+> zero tests and pass trivially, providing no regression signal.
+>
+> Stage 3 therefore adds a dependency: somebody first uncomments
+> (or rewrites) the test bodies against the Apache Impala fixture
+> and verifies they pass locally. Once a real test count exists,
+> Stage 3 lands as originally planned.
 
 This is the bullet ADR-0029's Follow-ups list defers to *this* ADR.
 
@@ -231,12 +247,25 @@ This is the bullet ADR-0029's Follow-ups list defers to *this* ADR.
 
 ## Follow-ups
 
-- **Stage 1 PR** — replace `tests/environments/bigdata/impala/docker-compose.yml`,
-  delete `tests/environments/hadoop/`, update
-  `tests/environments/README.md`. Status: pending audit.
-- **Stage 2 PR (conditional)** — Kudu service re-introduction if the
-  existing tests need it. Likely a one-line addition to the Stage 1
-  compose file.
+- **Stage 1 mechanical PR** — `tests/environments/hadoop/` deletion +
+  `tests/environments/README.md` update. **Landed in PR #110**
+  (`1f2cd4f`).
+- **Stage 1 substantive PR** — replace
+  `tests/environments/bigdata/impala/docker-compose.yml` with the
+  `apache/impala:4.5.0-*` quickstart translation, vendor
+  `quickstart_conf/hive-site.xml`. The compose lands without local
+  Docker validation (the originating session lacked a Docker
+  daemon); the next contributor with `docker compose up` access
+  should boot it once and confirm `localhost:21050` accepts a
+  pyodbc connection before merging anything that depends on it.
+- **Stage 2 PR (conditional)** — Kudu service re-introduction if a
+  future test needs it. Likely a one-paragraph addition to the
+  Stage 1 compose file plus an `apache/kudu:1.17.0` image pin.
+- **Stage 3 prerequisite PR** — uncomment / rewrite
+  `tests/integrationtests/integrator/integration/bigdata/impala/test_integration_*.py`
+  (both files are stubs today: every line is `# from unittest …`).
+  The CI job in Stage 3 has nothing meaningful to run until this
+  lands.
 - **Stage 3 PR** — `impala:` job in
   `.github/workflows/integration-tests.yml`, plus a CHANGELOG entry
   closing the ADR-0029 Follow-ups bullet.
@@ -254,6 +283,7 @@ This is the bullet ADR-0029's Follow-ups list defers to *this* ADR.
 - Apache Impala project: <https://impala.apache.org/>
 - Apache Impala Docker quickstart: <https://github.com/apache/impala/tree/master/docker>
 - Apache Kudu project: <https://kudu.apache.org/>
+- Vendored config: `tests/environments/bigdata/impala/quickstart_conf/hive-site.xml` — copied verbatim from the upstream `apache/impala/docker/quickstart_conf/`.
 
 ## Revision history
 
@@ -272,3 +302,16 @@ This is the bullet ADR-0029's Follow-ups list defers to *this* ADR.
   pins Dependabot can track. Stage 3's Negative consequences
   expanded with the realities of multi-service boot ordering on
   Actions and the HMS image's ~1.82 GB pull cost.
+- **2026-04-25** (Stage 1 substantive translation, same day). The
+  Stage 1 compose translation lands without local Docker validation
+  (originating session lacked a daemon). Vendors the upstream
+  `quickstart_conf/hive-site.xml` — the only config file the
+  upstream cluster mounts. While reading the matching test target
+  for Stage 3, surfaces that
+  `tests/integrationtests/integrator/integration/bigdata/impala/`
+  is currently two stub files: every line is `# from unittest …`,
+  the test bodies are entirely commented out. Stage 3 grows a new
+  prerequisite — a separate PR that uncomments / rewrites the
+  tests against the new fixture before the CI job can produce a
+  meaningful regression signal. The §Decision text and the
+  §Follow-ups list are updated accordingly.

--- a/tests/environments/README.md
+++ b/tests/environments/README.md
@@ -19,7 +19,7 @@ tracks the Docker ecosystem and opens weekly PRs when a new tag lands.
 | SQL Server | `mcr.microsoft.com/mssql/server:2022-latest` | 1433 | `sa / yourStrong(!)Password` | ✅ |
 | Oracle XE | `gvenzl/oracle-xe:21-slim-faststart` | 1521 | `pdi / pdi!123456 / test_pdi` | ✅ |
 | Kafka | `confluentinc/cp-kafka:7.7.1` + `cp-zookeeper:7.7.1` | 29092 (host), 9092 (inter-broker) | no auth | ✅ |
-| Impala + Kudu | `ibisproject/impala`, `parrotstream/kudu:latest` | 21050 (Impala), 7051 (Kudu master) | no auth | ⚠ unmaintained; ADR-0030 migration pending — see policy below |
+| Impala | `apache/impala:4.5.0-impala_quickstart_hms` + `-statestored` + `-catalogd` + `-impalad_coord_exec` | 21050 (HS2), 25000 (debug UI) | no auth | ⚠ compose translated from upstream `apache/impala/docker/quickstart.yml`, **not yet locally validated** — see ADR-0030 |
 
 ## Boot + tear-down recipe
 
@@ -48,16 +48,21 @@ at your host / credentials before running.
 
 ## Unmaintained-image policy
 
-The `bigdata/impala/` fixture sits on third-party images
-(`ibisproject/impala` + `parrotstream/kudu`) that stopped receiving
-updates around 2020. We leave it pinned to its last-known-good tag
-with a `# unmaintained; see header` marker in-line. Any new big-data
-integration test should either (a) add its backend as a new
-subdirectory with a maintained image, or (b) wait for the Stage 1
-migration PR planned in
-[ADR-0030](../../docs/governance/adr/0030-hadoop-impala-fixture-migration.md)
-which replaces it with the Apache-official `apache/impala:4.5.0-*`
-quickstart cluster.
+The `bigdata/impala/` fixture has been **migrated to Apache-official
+`apache/impala:4.5.0-*` images** as part of [ADR-0030](../../docs/governance/adr/0030-hadoop-impala-fixture-migration.md)
+Stage 1. The compose is a faithful translation of the upstream
+[`apache/impala/docker/quickstart.yml`](https://github.com/apache/impala/tree/master/docker)
+(HMS + statestored + catalogd + impalad_coord_exec) with the
+single config file (`hive-site.xml`) vendored under `quickstart_conf/`.
+The `parrotstream/kudu` services were dropped — no Impala test today
+exercises Kudu code paths; ADR-0030 Stage 2 re-introduces a
+maintained `apache/kudu:1.17.0` if a future test needs it.
+
+**The new compose has not yet been booted locally** by the session
+that wrote it (no Docker daemon was available); the next contributor
+running `docker compose up` should confirm `localhost:21050` accepts
+a pyodbc connection before merging anything that depends on the
+fixture. Until that validation lands, treat the fixture as draft.
 
 The previously-listed `hadoop/` fixture
 (`bde2020/hadoop-*:2.0.0-hadoop3.2.1-java8`) was deleted in the

--- a/tests/environments/bigdata/impala/docker-compose.yml
+++ b/tests/environments/bigdata/impala/docker-compose.yml
@@ -1,85 +1,118 @@
-# Impala + Kudu cluster for the ``[integrator]`` bigdata tests.
+# Impala fixture — Apache-official ``apache/impala:4.5.0-*`` images,
+# modelled on the upstream
+# https://github.com/apache/impala/blob/master/docker/quickstart.yml
+# layout (HMS + statestored + catalogd + impalad_coord_exec).
 #
-# ⚠ LEGACY — the Impala and Kudu images (``ibisproject/impala``,
-# ``parrotstream/kudu:latest``) are third-party and no longer
-# updated. Same caveat as ``../hadoop/docker-compose.yml``: the
-# bigdata fixture as a whole is staged for a follow-up migration
-# to Apache-official or community-maintained replacements.
+# Why these images: ADR-0030 (Stage 1) replaces the previous
+# unmaintained ``ibisproject/impala`` + ``parrotstream/kudu:latest``
+# fixture. Apache Impala 4.5.0 ships its quickstart cluster as five
+# componentised images on Docker Hub — there is no all-in-one
+# variant, so the compose has more services than the SQL fixtures
+# but every image is on a maintained release line that Dependabot
+# (Docker ecosystem, ADR-0025) can track.
 #
-# In the meantime we still pin the one image we control — the
-# metastore backend ``postgres`` — to match the main postgres
-# fixture. The third-party images stay on their historical tags.
+# What's left out vs upstream quickstart.yml:
+#
+# - Kudu (``apache/kudu``) — the upstream ``-kudu_master_hosts``
+#   flag in the impalad command stays for parity, but no Kudu
+#   service is started here. The pdip Impala adapter does not
+#   exercise Kudu code paths in any test under
+#   ``tests/integrationtests/integrator/integration/bigdata/impala/``
+#   today, so booting Kudu would be wasted runner time. ADR-0030
+#   Stage 2 adds it conditionally if a future test needs it.
+#
+# - The ``QUICKSTART_LISTEN_ADDR`` / ``QUICKSTART_IP`` / external
+#   ``quickstart-network`` plumbing — those exist in the upstream
+#   quickstart so an interactive user can reach the cluster from
+#   other hosts. The CI fixture doesn't need them; a default
+#   compose-managed bridge network and host port publishes are
+#   enough.
+#
+# Vendored config: ``./quickstart_conf/hive-site.xml`` is copied
+# verbatim from the upstream
+# ``apache/impala/docker/quickstart_conf/`` directory. It is the
+# only config file the upstream quickstart mounts; the impala
+# images use their built-in defaults for everything else.
+#
+# Boot ordering: ``depends_on`` here matches the upstream quickstart
+# (postgres skipped because we use the embedded Derby HMS backing
+# store from the upstream config). GitHub Actions ``services:``
+# blocks ignore ``depends_on``, so the matching workflow job (when
+# Stage 3 lands) will need a Python-based readiness probe that
+# polls the impalad's HS2 endpoint on ``localhost:21050``.
 
 services:
-  postgres:
-    image: postgres:16-alpine  # pinned, matches ../../postgresql/
+  hms:
+    image: apache/impala:4.5.0-impala_quickstart_hms  # pinned major.minor
+    container_name: quickstart-hive-metastore
+    command: ["hms"]
+    volumes:
+      # Apache Derby database files (HMS metadata).
+      - impala-quickstart-warehouse:/var/lib/hive
+      # Warehouse directory shared with catalogd / impalad.
+      - impala-quickstart-warehouse:/user/hive/warehouse
+      - ./quickstart_conf:/opt/hive/conf:ro
     networks:
       - impala-nw
+
+  statestored:
+    image: apache/impala:4.5.0-statestored  # pinned major.minor
     ports:
-      - 5432:5432
-    environment:
-      POSTGRES_PASSWORD: postgres
-  impala:
-    build: .
-    cap_add:
-      - SYS_TIME
-    image: ibisproject/impala  # unmaintained; see header
-    hostname: localhost
+      - "25010:25010"  # web debug UI
+    command: ["-redirect_stdout_stderr=false", "-logtostderr", "-v=1"]
+    volumes:
+      - ./quickstart_conf:/opt/impala/conf:ro
     networks:
       - impala-nw
-    external_links:
-      - postgres
-    environment:
-      PGPASSWORD: postgres
+
+  catalogd:
+    depends_on:
+      - statestored
+      - hms
+    image: apache/impala:4.5.0-catalogd  # pinned major.minor
     ports:
-      # HDFS
-      - 9020:9020
-      - 50070:50070
-      - 50075:50075
-      - 8020:8020
-      - 8042:8042
-      # Hive
-      - 9083:9083
-      # Impala
-      - 21000:21000
-      - 21050:21050
-      - 25000:25000
-      - 25010:25010
-      - 25020:25020
-  kudu-master:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: parrotstream/kudu:latest  # unmaintained; see header
-    networks:
-      impala-nw:
-        aliases:
-          - kudu
-    cap_add:
-      - SYS_TIME
-    ports:
-      - 7051:7051
-      - 8051:8051
-    environment:
-      KUDU_MASTER: "true"
-  kudu-tserver:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: parrotstream/kudu:latest  # unmaintained; see header
+      - "25020:25020"  # web debug UI
+    command: ["-redirect_stdout_stderr=false", "-logtostderr", "-v=1",
+              "-hms_event_polling_interval_s=1",
+              "-invalidate_tables_timeout_s=999999"]
+    volumes:
+      - impala-quickstart-warehouse:/user/hive/warehouse
+      - ./quickstart_conf:/opt/impala/conf:ro
     networks:
       - impala-nw
-    cap_add:
-      - SYS_TIME
+
+  impalad:
+    image: apache/impala:4.5.0-impalad_coord_exec  # pinned major.minor
+    depends_on:
+      - statestored
+      - catalogd
     ports:
-      - 7050:7050
-      - 8050:8050
+      - "21000:21000"  # Beeswax (legacy)
+      - "21050:21050"  # HS2 endpoint — what pyodbc connects to
+      - "25000:25000"  # web debug UI
+      - "28000:28000"  # HS2 over HTTP
+    command: ["-v=1",
+              "-redirect_stdout_stderr=false", "-logtostderr",
+              # Kudu master flag stays for upstream parity; no Kudu
+              # service is started in this fixture (see header).
+              # Non-Kudu queries are unaffected.
+              "-kudu_master_hosts=kudu-master-1:7051",
+              "-mt_dop_auto_fallback=true",
+              "-default_query_options=mt_dop=4,default_file_format=parquet,default_transactional_type=insert_only",
+              "-mem_limit=4gb"]
     environment:
-      KUDU_MASTER: "false"
+      # Cap the JVM so the runner has memory left for the query
+      # backend.
+      JAVA_TOOL_OPTIONS: "-Xmx1g"
+    volumes:
+      - impala-quickstart-warehouse:/user/hive/warehouse
+      - ./quickstart_conf:/opt/impala/conf:ro
+    networks:
+      - impala-nw
+
+volumes:
+  impala-quickstart-warehouse:
 
 networks:
-  default:
-    external:
-      name: impala-nw
   impala-nw:
     driver: bridge

--- a/tests/environments/bigdata/impala/quickstart_conf/hive-site.xml
+++ b/tests/environments/bigdata/impala/quickstart_conf/hive-site.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+Hive configuration for Impala quickstart docker cluster.
+-->
+<configuration>
+      <property>
+        <!-- Required for automatic metadata sync. -->
+        <name>hive.metastore.dml.events</name>
+        <value>true</value>
+      </property>
+      <property>
+        <!-- User impala is not authorized to consume notifications by default, disable
+             authentication to work around this. -->
+         <name>hive.metastore.event.db.notification.api.auth</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://quickstart-hive-metastore:9083</value>
+      </property>
+      <!-- Managed and external tablespaces must live on the Docker volumes that we
+           configure for the quickstart cluster. -->
+      <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>/user/hive/warehouse/managed</value>
+      </property>
+      <property>
+        <name>hive.metastore.warehouse.external.dir</name>
+        <value>/user/hive/warehouse/external</value>
+      </property>
+      <property>
+        <!-- Required to enable Hive transactions -->
+        <name>hive.support.concurrency</name>
+        <value>true</value>
+      </property>
+      <property>
+        <!-- Required to enable Hive transactions -->
+        <name>hive.txn.manager</name>
+        <value>org.apache.hadoop.hive.ql.lockmgr.DbTxnManager</value>
+      </property>
+      <property>
+        <!-- Use embedded Derby database -->
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>org.apache.derby.jdbc.EmbeddedDriver</value>
+      </property>
+      <property>
+        <!-- Use embedded Derby database -->
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:derby:;databaseName=/var/lib/hive/metastore/metastore_db;create=true</value>
+      </property>
+      <!-- Hive stats autogathering negatively affects latency of DDL operations, etc and
+           is not particularly useful for Impala -->
+      <property>
+        <name>hive.stats.autogather</name>
+        <value>false</value>
+      </property>
+</configuration>


### PR DESCRIPTION
## Summary

ADR-0030 Stage 1 substantive part — translates the upstream [`apache/impala/docker/quickstart.yml`](https://github.com/apache/impala/tree/master/docker) into `tests/environments/bigdata/impala/docker-compose.yml`, replacing the previous unmaintained `ibisproject/impala` + `parrotstream/kudu:latest` pin with the maintained `apache/impala:4.5.0-*` image family.

### What landed

| Service | Image | Purpose |
|---|---|---|
| `hms` | `apache/impala:4.5.0-impala_quickstart_hms` | Hive Metastore + embedded Apache Derby backing store |
| `statestored` | `apache/impala:4.5.0-statestored` | Cluster membership / state |
| `catalogd` | `apache/impala:4.5.0-catalogd` | Metadata cache |
| `impalad` | `apache/impala:4.5.0-impalad_coord_exec` | Combined coordinator + executor; HS2 endpoint on `21050` |

Plus the upstream's only mounted config file (`hive-site.xml`), vendored verbatim under `tests/environments/bigdata/impala/quickstart_conf/`.

### What was dropped

- `parrotstream/kudu` master + tserver — no Impala test today exercises Kudu code paths. ADR-0030 Stage 2 re-introduces `apache/kudu:1.17.0` conditionally.
- `QUICKSTART_LISTEN_ADDR` / `QUICKSTART_IP` env-var machinery and the external `quickstart-network` — the CI fixture doesn't need to advertise to other hosts. Default compose-managed bridge network + host port publishes are enough.

### ⚠ Not yet locally validated

The originating session lacked a Docker daemon, so the new compose has not been booted end-to-end. Before merging anything that depends on this fixture, the next contributor should `docker compose up -d`, wait for boot (~minutes for the HMS + impalad chain), and confirm `localhost:21050` accepts a pyodbc connection. The README and ADR-0030 both flag this explicitly.

### Stage 3 also gained a prerequisite

While reading the matching test target for Stage 3, this session discovered that `tests/integrationtests/integrator/integration/bigdata/impala/test_integration_*.py` is exactly two stub files — every line is `# from unittest …`. A CI job wired today would `unittest discover` zero tests and pass trivially. ADR-0030's `## Follow-ups` list and `## Revision history` are updated to record this; Stage 3 now depends on a separate prerequisite PR that uncomments or rewrites the test bodies against the new fixture.

## Test plan

- [ ] CI matrix passes (no Python source touched; lint + unit tests stay green).
- [ ] Integration-tests workflow's self-test trigger fires on this PR — but no `impala:` job exists yet, so the existing `postgres:` / `mysql:` / `oracle:` / `mssql:` jobs run unchanged.
- [ ] Manual local validation by a maintainer with Docker access before this fixture is referenced by any merged-to-main test or workflow.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFRfygucKKrdUjzdz3iwbn)_