### PR TITLE
docs(handoff): post-merge refresh — Async/OTel/1.0 landed via #116

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -23,11 +23,12 @@
 
 ## 2. Open PRs
 
-No tracked open PRs as of 2026-04-25. The three Dependabot bumps that were
-previously open here (#61 pyodbc 5.3.0, #63 markupsafe 3.0.3, #64 oracledb
-upper-bound to allow 3.x) have all merged after a surface-area audit
-against the adapter call sites — see commits `cdd1bb5`, `ead2013`,
-`a799d7d`.
+No tracked open PRs as of 2026-04-25. The Async / OTel / 1.0 cut work
+landed on `main` as **#116** (squash-merged) — see §4 for the full
+list of slices that came in with that PR. Earlier Dependabot bumps
+(#61 pyodbc 5.3.0, #63 markupsafe 3.0.3, #64 oracledb upper-bound to
+allow 3.x) merged after a surface-area audit against the adapter
+call sites — see commits `cdd1bb5`, `ead2013`, `a799d7d`.
 
 When new PRs come in, list them here with the same four columns
 (`#`, `What`, `Next action`, `Why deferred`) so the next reader can act
@@ -42,17 +43,9 @@ of this file. Most `claude/*` branches on the remote are post-merge
 artifacts from squash-merged PRs — safe to ignore unless a name below is
 listed. **Reserved (not yet pushed):**
 
-- `claude/handoff-start-continue-OolIR` — Async / OTel / 1.0 ADR
-  trio (ADR-0032 / 0033 / 0034 — all Accepted) **plus the three
-  foundation slices and five follow-up slices** (factory
-  `is_async` flag, `Integrator.integrate` job span, ADR-0034
-  quality_guard coverage rule, cross-process `traceparent`
-  propagation through `ProcessManager` ↔ `Subprocess`,
-  `AsyncIntegrationExecute` ABC + strategy-factory `is_async`
-  flag). Pushed for review; not yet merged to `main`. See §4
-  "Async / OpenTelemetry / 1.0 cut" for the full landed list and
-  what is still queued (asyncpg end-to-end Postgres connector +
-  adapter wiring, signature-baseline guard).
+- No active reserved branches at the moment.
+  `claude/handoff-start-continue-OolIR` is now a post-merge artifact
+  of #116; safe to ignore.
 
 If you find a `claude/*` branch not listed here and not associated with an
 open PR, it is almost certainly stale — confirm with `git log
@@ -67,7 +60,7 @@ ADR if the answer changed.
 |---|---|---|
 | Kafka nightly integration job | Smoke-test scaffold for `KafkaConnector` lives at `tests/integrationtests/integrator/connection/queue/kafka/` and runs locally against `tests/environments/kafka/docker-compose.yml`. The matching nightly CI job did *not* land — four image / config combinations failed (cp-kafka + cp-zookeeper, apache/kafka 3.7 KRaft, bitnami/kafka 3.7 KRaft, plus a debug log-dump variant) and the Actions logs are auth-walled to non-collaborators. | A maintainer with collaborator access reads the actual job log to identify the broker-exit cause, then opens one targeted fix PR adding the `kafka:` job to `.github/workflows/integration-tests.yml`. |
 | Hadoop / Impala fixtures + bigdata nightly | [ADR-0030](governance/adr/0030-hadoop-impala-fixture-migration.md) (Status: Proposed). Stage 1 fully landed: mechanical part in #110 (deleted `tests/environments/hadoop/`), substantive part in #114 (translated upstream `apache/impala/docker/quickstart.yml` into a 4-service fixture under `tests/environments/bigdata/impala/` + vendored `quickstart_conf/hive-site.xml`). | Two open prerequisites before Stage 3 (`impala:` nightly job) lands: (a) maintainer with Docker access boots the new fixture and confirms `localhost:21050` accepts pyodbc — fixture has not been locally validated; (b) somebody uncomments / rewrites the test bodies under `tests/integrationtests/integrator/integration/bigdata/impala/test_integration_*.py`, which today are stub files (every line is `# from unittest …`). |
-| Async / OpenTelemetry / 1.0 cut | **All three ADRs Accepted, foundation slices + five follow-ups landed on `claude/handoff-start-continue-OolIR`** ([ADR-0032](governance/adr/0032-hybrid-async-strategy.md) / [ADR-0033](governance/adr/0033-opentelemetry-observability.md) / [ADR-0034](governance/adr/0034-one-zero-readiness-criteria.md); ADR-0007 carries a header note pointing to ADR-0032). **Foundation slices** (one per ADR): (1) ADR-0034 — every documented public package declares `__all__`, `docs/public-api.md` mirrors the contract, drift contract test in `tests/unittests/public_api/`. (2) ADR-0033 — `pdip/observability/` lazy `get_tracer` / `get_meter` (no-op-by-default, `PDIP_OBSERVABILITY_ENABLED` toggle, OTel-missing fallback), the `pdip[observability]` extra, `Dispatcher.dispatch` instrumented with `pdip.cqrs.command` / `pdip.cqrs.query` spans + `pdip.cqrs.handler` attribute. (3) ADR-0032 — `AsyncConnectionSourceAdapter` / `AsyncConnectionTargetAdapter` abstract bases + the `pdip[async]` extra (asyncpg / aiomysql / aioodbc / aiokafka). **Follow-ups landed on top**: (b) `is_async` flag on both `ConnectionSourceAdapterFactory.get_adapter` and `ConnectionTargetAdapterFactory.get_adapter`; the new helper `pdip/integrator/connection/base/_async_extra.py::require_async_extra()` raises a clean `ImportError` with `pdip[async]` install hint when the extra is missing, and the factories raise `NotSupportedFeatureException` for every connection type until the async siblings land. (d-1) `Integrator.integrate` now opens a `pdip.integrator.job` span carrying `pdip.integration.id` / `pdip.integration.name` (safe defaults when the operation fields are `None`); argument-validation errors don't open a span. (e) New quality_guard rule `RuleADR0034NoUndocumentedTopLevelPackage` plus `_ADR0034_INTERNAL_PACKAGES` allowlist (currently just `pdip.base`) — pre-commit suite is now 7 rules. (d-2) Cross-process W3C `traceparent` propagation: `pdip.observability.inject_context` (parent side, returns picklable dict carrier) + `pdip.observability.use_context` (worker side, attaches the extracted context for the duration of `target_method`); `ProcessManager.start_processes` injects the carrier into a fresh kwargs copy under `_pdip_trace_carrier` and `Subprocess.start` pops it before invoking user code. Lazy + no-op when observability disabled or OTel missing — caller dict is never mutated. (c) `AsyncIntegrationExecute` ABC under `pdip/integrator/integration/types/sourcetotarget/strategies/async_/base/`; `IntegrationSourceToTargetExecuteStrategyFactory.get(process_count, is_async=False)` learns the new flag — `is_async=True` short-circuits with `NotSupportedFeatureException` pointing at ADR-0032 follow-up until a concrete async strategy lands. | **Still queued for follow-up sessions** — both fundamentally outside one tractable unit-test-driven slice: (a) async Postgres sibling **end-to-end** via `asyncpg` under `pdip/integrator/connection/types/sql/connectors/postgresql/` + `AsyncSqlSourceAdapter` / `AsyncSqlTargetAdapter` wiring, gated by integration tests against a real Postgres instance; this also unlocks unblocking the `is_async=True` paths on the adapter factories so they return real adapters instead of `NotSupportedFeatureException`. (e-2) Signature-baseline guard for ADR-0034 §5 — needs its own design ADR to pick the baseline source (PyPI sdist / git-tag introspection / checked-in snapshot) and the diff algorithm; the `signature guard` row in ADR-0034 §5 already records this. **Optional next steps that are tractable in unit tests**: deeper ADR-0033 instrumentation — `pdip.integrator.source.read` / `pdip.integrator.target.write` spans at the adapter call sites inside the strategy modules (`singleprocess/`, `parallelthread/` — note `parallelthread/` is currently excluded from unit coverage by `.coveragerc` so plan accordingly). TDD focus still mandated — ADR-0027 diff-cover 100 % gate + ADR-0026 / ADR-0034 quality_guard rules (now 7 rules). |
+| Async / OpenTelemetry / 1.0 cut | **All three ADRs Accepted, foundation + five follow-ups landed on `main` as #116** ([ADR-0032](governance/adr/0032-hybrid-async-strategy.md) hybrid async / [ADR-0033](governance/adr/0033-opentelemetry-observability.md) OTel / [ADR-0034](governance/adr/0034-one-zero-readiness-criteria.md) 1.0 readiness; ADR-0007 carries a header note pointing to ADR-0032). What is now on `main`: every documented public package declares `__all__` and is mirrored in `docs/public-api.md`; `pdip.observability` is a public package exporting `get_tracer` / `get_meter` / `inject_context` / `use_context` (lazy no-op-by-default, `PDIP_OBSERVABILITY_ENABLED` toggle, OTel-missing fallback); `pdip[observability]` and `pdip[async]` extras live in `setup.py`; `Dispatcher.dispatch` and `Integrator.integrate` emit `pdip.cqrs.{command,query}` and `pdip.integrator.job` spans with the documented attributes; `AsyncConnectionSourceAdapter` / `AsyncConnectionTargetAdapter` abstract bases live next to their sync siblings, with an `is_async` flag on the source/target adapter factories that raises a clean `ImportError` (via `pdip/integrator/connection/base/_async_extra.py::require_async_extra()`) when the extra is missing and `NotSupportedFeatureException` until concrete async siblings land; `AsyncIntegrationExecute` ABC and an `is_async` flag on `IntegrationSourceToTargetExecuteStrategyFactory.get` are in place with the same staged-failure pattern; cross-process W3C `traceparent` propagation is wired through `ProcessManager.start_processes` ↔ `Subprocess.start` via `_pdip_trace_carrier`; ADR-0034 §5 has shipped both the drift contract test (`tests/unittests/public_api/`) and the new `RuleADR0034NoUndocumentedTopLevelPackage` quality_guard rule (pre-commit suite is now 7 rules). | **Still queued for follow-up sessions** — both fundamentally outside one tractable unit-test-driven slice: (a) async Postgres sibling **end-to-end** via `asyncpg` under `pdip/integrator/connection/types/sql/connectors/postgresql/` + `AsyncSqlSourceAdapter` / `AsyncSqlTargetAdapter` wiring, gated by integration tests against a real Postgres instance; this also unblocks the `is_async=True` paths on the adapter factories so they return real adapters instead of `NotSupportedFeatureException`. (e-2) Signature-baseline guard for ADR-0034 §5 — needs its own design ADR to pick the baseline source (PyPI sdist / git-tag introspection / checked-in snapshot) and the diff algorithm; the `signature guard` row in ADR-0034 §5 already records this. **Optional next-tractable item in unit tests**: deeper ADR-0033 instrumentation — `pdip.integrator.source.read` / `pdip.integrator.target.write` spans at the adapter call sites inside the strategy modules (`singleprocess/` is in unit coverage; `parallelthread/` and `parallelold/` are currently excluded by `.coveragerc` so plan accordingly). TDD focus still mandated — ADR-0027 diff-cover 100 % gate + ADR-0026 / ADR-0034 quality_guard rules (now 7 rules). |
 
 ## 5. Read this first
 
@@ -89,20 +82,14 @@ rest.
 
 ---
 
-*Last updated 2026-04-25 on `claude/handoff-start-continue-OolIR`
-(after two more follow-up slices landed: cross-process W3C
-`traceparent` propagation via the new
-`pdip.observability.inject_context` / `use_context` helpers wired
-through `ProcessManager.start_processes` and `Subprocess.start`;
-and `AsyncIntegrationExecute` ABC under
-`strategies/async_/base/` + an `is_async` flag on
-`IntegrationSourceToTargetExecuteStrategyFactory.get` that raises
-`NotSupportedFeatureException` until a concrete async strategy
-lands. Branch now carries 8 first-implementation slices on top of
-the three Accepted ADRs; sits at 100 % unit coverage on the
-canonical `run_tests.py` cell (731 tests) with all 7 quality_guard
-rules green. Remaining queued work — asyncpg end-to-end Postgres
-sibling + signature-baseline guard ADR — recorded in §4
-Async/OTel/1.0 row.). When you change anything above, bump this
-line with the date and the branch name so the next reader knows
-the freshness window at a glance.*
+*Last updated 2026-04-25 on `claude/handoff-post-merge-OolIR`
+(after #116 squash-merged the Async / OTel / 1.0 readiness work to
+`main`: three ADRs Accepted, three foundation slices, five
+follow-up slices — full breakdown in §4 Async/OTel/1.0 row).
+`main` now sits at 100 % unit coverage on the canonical
+`run_tests.py` cell (731 tests) with all 7 quality_guard rules
+green and the new `pdip.observability` package as a public surface
+entry. Remaining queued work — asyncpg end-to-end Postgres
+sibling + signature-baseline guard ADR — recorded in §4. When you
+change anything above, bump this line with the date and the branch
+name so the next reader knows the freshness window at a glance.*


### PR DESCRIPTION
## Summary

Refresh of `docs/handoff.md` after #116 squash-merged the Async / OpenTelemetry / 1.0 readiness foundation + five follow-ups to `main`. Pure documentation — no code changes.

- **§2 Open PRs** notes #116 as the freshly-landed PR.
- **§3 Branches** clears the previously-reserved `claude/handoff-start-continue-OolIR` (now a post-merge artifact, safe to ignore).
- **§4 Async / OpenTelemetry / 1.0 cut** rewritten in past-tense "what is now on `main`" form, with the two queued follow-ups (asyncpg end-to-end Postgres + signature-baseline guard ADR) preserved as the next-action pointer.
- **Footer** bumped to `claude/handoff-post-merge-OolIR` with the current freshness summary.

## Test plan

- [x] Pure markdown changes; no code or tests touched.
- [x] Internal links resolve — every ADR / `__init__.py` / test path mentioned exists on `main` after #116.
- [x] No claim in the new wording exceeds what landed in #116 (cross-checked against the merged diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0194A1BAP2RHQKwRKRuCcKUN)_