### PR TITLE
docs(handoff): bookkeeping refresh — add #123 to PR chain + branch artifact list

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -30,17 +30,17 @@ five follow-ups), **#117** (post-merge handoff refresh), **#118**
 **#119** (post-#118 handoff refresh), **#120** (async
 MySQL/MSSQL/Oracle skeletons + Postgres `clear_data` end-to-end +
 `SingleProcessIntegrationExecute` adapter-call-site spans + ADR-0036
-Proposed), **#121** (post-#120 handoff refresh), and **#122** —
-the finishing slice that lands `pdip.__version__` + ADR-0036
-Accepted with both quality_guard rules + Postgres `write_data` /
+Proposed), **#121** (post-#120 handoff refresh), **#122** — the
+finishing slice that lands `pdip.__version__` + ADR-0036 Accepted
+with both quality_guard rules + Postgres `write_data` /
 `do_target_operation` / iterator / paging end-to-end +
 `parallelthread/` adapter-call-site spans + the integration-tests
 CI nightly installing `pdip[async]` and running the per-backend
-async smoke suites. See §4 for the full breakdown. Earlier
-Dependabot bumps (#61 pyodbc 5.3.0, #63 markupsafe 3.0.3, #64
-oracledb upper-bound to allow 3.x) merged after a surface-area
-audit against the adapter call sites — see commits `cdd1bb5`,
-`ead2013`, `a799d7d`.
+async smoke suites — and **#123** (post-#122 handoff refresh).
+See §4 for the full breakdown. Earlier Dependabot bumps
+(#61 pyodbc 5.3.0, #63 markupsafe 3.0.3, #64 oracledb upper-bound
+to allow 3.x) merged after a surface-area audit against the
+adapter call sites — see commits `cdd1bb5`, `ead2013`, `a799d7d`.
 
 When new PRs come in, list them here with the same four columns
 (`#`, `What`, `Next action`, `Why deferred`) so the next reader can act
@@ -63,8 +63,9 @@ listed. **Reserved (not yet pushed):**
   `claude/handoff-post-118-refresh-OolIR` (#119),
   `claude/handoff-async-backends-spans-OolIR` (#120),
   `claude/handoff-post-120-refresh-OolIR` (#121),
-  `claude/handoff-finish-stream-OolIR` (#122), and the current
-  branch once its PR squash-merges.
+  `claude/handoff-finish-stream-OolIR` (#122),
+  `claude/handoff-post-122-refresh-OolIR` (#123), and the
+  current branch once its PR squash-merges.
 
 If you find a `claude/*` branch not listed here and not associated with an
 open PR, it is almost certainly stale — confirm with `git log
@@ -101,18 +102,20 @@ rest.
 
 ---
 
-*Last updated 2026-04-25 on `claude/handoff-post-122-refresh-OolIR`
-(post-merge refresh after #122 squash-merged the finishing slice
-of the Async / OTel / 1.0 readiness work-stream to `main`).
-`main` is at `582f35d`; the work-stream is now contractually +
-architecturally complete with five Accepted ADRs (0032 / 0033 /
-0034 / 0035 / 0036), a public surface that includes
-`pdip.__version__` + `pdip.observability` + the async adapter
-chain wired Postgres-end-to-end through both connection
-factories, ADR-0034 §5 enforcement complete in **four layers,
-all shipped** (drift / coverage / signature / deprecation-cycle),
-the `singleprocess/` AND `parallelthread/` strategies emitting
-the documented adapter-call-site spans via the shared
+*Last updated 2026-04-25 on `claude/handoff-post-123-refresh-OolIR`
+(bookkeeping refresh — adds #123 to §2's PR chain and
+`claude/handoff-post-122-refresh-OolIR` to §3's post-merge
+artifact list so the trail stays complete after the post-#122
+docs PR landed). `main` is at `7f36829`; the Async / OTel / 1.0
+readiness work-stream remains contractually + architecturally
+complete with five Accepted ADRs (0032 / 0033 / 0034 / 0035 /
+0036), a public surface that includes `pdip.__version__` +
+`pdip.observability` + the async adapter chain wired
+Postgres-end-to-end through both connection factories, ADR-0034
+§5 enforcement complete in **four layers, all shipped** (drift
+/ coverage / signature / deprecation-cycle), the `singleprocess/`
+AND `parallelthread/` strategies emitting the documented
+adapter-call-site spans via the shared
 `strategies/base/span_helpers.py`, and the integration-tests CI
 nightly installing `pdip[integrator,async]` + running the
 per-backend async smoke suites alongside the sync integration


### PR DESCRIPTION
## Summary

Pure bookkeeping refresh so `docs/handoff.md` §2 / §3 stays accurate after #123 (the post-#122 handoff refresh) landed on `main`.

- **§2 Open PRs** — #123 added to the Async / OTel / 1.0 cut PR chain enumeration so the trail reads #116 → #117 → #118 → #119 → #120 → #121 → #122 → #123.
- **§3 Branches** — `claude/handoff-post-122-refresh-OolIR` (#123) added to the post-merge artifact list (now eight post-merge `claude/*` branches all safe to ignore).
- **Footer** — bumped to `claude/handoff-post-123-refresh-OolIR`, `main` reference updated to the post-#123 SHA `7f36829`.

No code or test changes; the work-stream's substantive state is unchanged from #122 + #123 — five Accepted ADRs, four-layer ADR-0034 §5 enforcement, Postgres-end-to-end async chain, singleprocess + parallelthread spans, integration-tests nightly running the per-backend async smoke jobs.

## Test plan

- [x] Pure markdown changes; no code or tests touched.
- [x] Internal links resolve — every PR / branch mentioned exists on `main` after #123.
- [x] No claim in the new wording exceeds what landed in #116-#123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0194A1BAP2RHQKwRKRuCcKUN)_