### PR TITLE
feat(adr-0033): parallelold/ adapter-call-site spans (a-4) + handoff refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ for the public API surface described in
 
 ### Added
 
+- **`parallelold/` multiprocessing strategy emits ADR-0033 §3
+  adapter-call-site spans (ADR-0032 §3 follow-up (a-4) — the last
+  foundation item on the Async / OTel / 1.0 work-stream).**
+  `ParallelIntegrationExecute` now wraps its three
+  `ConnectionSourceAdapter` / `ConnectionTargetAdapter` call sites
+  in the documented spans:
+  `start_source_data_operation` opens
+  `pdip.integrator.source.read` around `get_source_data_count`;
+  `start_execute_integration_with_source_data` opens
+  `pdip.integrator.target.write` around `write_data`; and
+  `start_execute_integration_with_paging` opens
+  `pdip.integrator.source.read` around the paged read followed by
+  `pdip.integrator.target.write` around the subsequent write. Each
+  span carries the documented `pdip.connection.{type,driver}` plus
+  `pdip.batch.size` (and `pdip.rows.written` on writes) attributes
+  and reuses the shared
+  `strategies/base/span_helpers.py::attr_name` /
+  `resolve_driver` resolvers so the SQL/BigData/WebService
+  sub-payload walking stays consistent with the singleprocess and
+  parallelthread strategies. Pinned by eight new unit tests under
+  `tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py`
+  exercising span name, ordering, attributes (including the
+  `Limit=None → batch.size=0` guard and the connector-type-driven
+  driver resolution), and the `transactionhandler`-decorated
+  `start_source_data_operation` entry point.
 - **Async SQL adapter chain wired end-to-end across all four
   backends (ADR-0032 §3 follow-up (a-3)).** New
   `pdip/integrator/connection/types/sql/base/async_sql_dialect.py`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -23,9 +23,12 @@
 
 ## 2. Open PRs
 
-No tracked open PRs as of 2026-04-26 (other than this handoff
-refresh itself). The Async / OTel / 1.0 cut work-stream landed
-on `main` across **#116** (foundation + first five follow-ups),
+No tracked open PRs as of 2026-04-26 (other than this branch's
+PR itself, which extends the Async / OTel / 1.0 work-stream by
+landing the last foundation item — span instrumentation of the
+`parallelold/` multiprocessing strategy (a-4) — and refreshes
+this handoff alongside it). The Async / OTel / 1.0 cut work-stream
+landed on `main` across **#116** (foundation + first five follow-ups),
 **#117** (post-merge handoff refresh), **#118** (asyncpg Postgres
 end-to-end + ADR-0035 signature-snapshot guard), **#119**
 (post-#118 handoff refresh), **#120** (async MySQL/MSSQL/Oracle
@@ -52,7 +55,9 @@ hardcoded `AsyncMssqlConnector`, bare-`mysql://` SQLAlchemy URL,
 bare-path Oracle URL → `?service_name=` for PDB lookup, MSSQL /
 Oracle smoke + sync setUps aligned to workflow credentials,
 MySQL `test_check_schema_and_tables` skipping system schemas
-that need `PROCESS`), and **#126** (post-#125 handoff refresh).
+that need `PROCESS`), **#126** (post-#125 handoff refresh), and
+**#127** (bookkeeping refresh adding #126 to the chain and
+`claude/handoff-post-125-refresh-OolIR` to §3's artifact list).
 See §4 for the full breakdown. Earlier
 Dependabot bumps (#61 pyodbc 5.3.0, #63 markupsafe 3.0.3, #64
 oracledb upper-bound to allow 3.x) merged after a surface-area
@@ -72,8 +77,10 @@ of this file. Most `claude/*` branches on the remote are post-merge
 artifacts from squash-merged PRs — safe to ignore unless a name below is
 listed. **Reserved (not yet pushed):**
 
-- No active reserved branches at the moment. Post-merge
-  artifacts safe to ignore:
+- **Active:** `claude/handoff-state-management-p13Rm` — lands the
+  `parallelold/` span instrumentation (a-4) and refreshes this
+  handoff. PR not yet open at refresh time. Post-merge artifacts
+  safe to ignore:
   `claude/handoff-start-continue-OolIR` (#116),
   `claude/handoff-post-merge-OolIR` (#117),
   `claude/handoff-asyncpg-sigguard-OolIR` (#118),
@@ -84,7 +91,8 @@ listed. **Reserved (not yet pushed):**
   `claude/handoff-post-122-refresh-OolIR` (#123),
   `claude/handoff-post-123-refresh-OolIR` (#124),
   `claude/review-handoff-async-50eob` (#125),
-  `claude/handoff-post-125-refresh-OolIR` (#126), and the current
+  `claude/handoff-post-125-refresh-OolIR` (#126),
+  `claude/handoff-post-126-refresh-OolIR` (#127), and the current
   branch once its PR squash-merges.
 
 If you find a `claude/*` branch not listed here and not associated with an
@@ -100,7 +108,7 @@ ADR if the answer changed.
 |---|---|---|
 | Kafka nightly integration job | Smoke-test scaffold for `KafkaConnector` lives at `tests/integrationtests/integrator/connection/queue/kafka/` and runs locally against `tests/environments/kafka/docker-compose.yml`. The matching nightly CI job did *not* land — four image / config combinations failed (cp-kafka + cp-zookeeper, apache/kafka 3.7 KRaft, bitnami/kafka 3.7 KRaft, plus a debug log-dump variant) and the Actions logs are auth-walled to non-collaborators. | A maintainer with collaborator access reads the actual job log to identify the broker-exit cause, then opens one targeted fix PR adding the `kafka:` job to `.github/workflows/integration-tests.yml`. |
 | Hadoop / Impala fixtures + bigdata nightly | [ADR-0030](governance/adr/0030-hadoop-impala-fixture-migration.md) (Status: Proposed). Stage 1 fully landed: mechanical part in #110 (deleted `tests/environments/hadoop/`), substantive part in #114 (translated upstream `apache/impala/docker/quickstart.yml` into a 4-service fixture under `tests/environments/bigdata/impala/` + vendored `quickstart_conf/hive-site.xml`). | Two open prerequisites before Stage 3 (`impala:` nightly job) lands: (a) maintainer with Docker access boots the new fixture and confirms `localhost:21050` accepts pyodbc — fixture has not been locally validated; (b) somebody uncomments / rewrites the test bodies under `tests/integrationtests/integrator/integration/bigdata/impala/test_integration_*.py`, which today are stub files (every line is `# from unittest …`). |
-| Async / OpenTelemetry / 1.0 cut | **All five ADRs Accepted (0032 / 0033 / 0034 / 0035 / 0036); the work-stream is contractually complete on `main`**. ADR-0034 §5 enforcement is now 4 layers, all shipped: drift contract test, `RuleADR0034NoUndocumentedTopLevelPackage` coverage rule, `RuleADR0035PublicApiSignatureSnapshotMatches` signature guard, and the new pair `RuleADR0036DeprecationWarningHasManifestEntry` + `RuleADR0036RemovalRespectsDeprecationCycle` deprecation-cycle guard reading `docs/public-api-deprecations.json`. `pdip.__version__` is exported as the single source of truth for the runtime version (read by the removal-cycle rule). `pdip.observability` exports `get_tracer` / `get_meter` / `inject_context` / `use_context`; `pdip[observability]` and `pdip[async]` extras live in `setup.py`; `Dispatcher.dispatch`, `Integrator.integrate`, `SingleProcessIntegrationExecute`, AND `parallelthread/operation/{source,target}` now emit `pdip.cqrs.{command,query}` / `pdip.integrator.job` / `pdip.integrator.source.read` / `pdip.integrator.target.write` spans with their documented attributes via the shared `strategies/base/span_helpers.py`; the async Sql chain dispatches via `_connector_for` to `AsyncPostgresqlConnector` / `AsyncMysqlConnector` / `AsyncMssqlConnector` / `AsyncOracleConnector` (lazy driver imports throughout); `AsyncSqlConnector` ABC has `connect`/`disconnect`/`fetch_count`/`execute`/`fetch_all`/`executemany`; **`AsyncSqlTargetAdapter` and `AsyncSqlSourceAdapter` are fully wired for ALL FOUR backends** — `clear_data` (TRUNCATE), `write_data` (executemany INSERT with column inference + dialect-specific placeholder ladder), `do_target_operation` (truncate-when-flag-set), `get_iterator` (in-memory chunked batches), `get_source_data_with_paging` (LIMIT/OFFSET on Postgres + MySQL, ANSI OFFSET/FETCH NEXT on MSSQL + Oracle), `get_source_data_count`. The dialect helper at `pdip/integrator/connection/types/sql/base/async_sql_dialect.py` centralises identifier quoting, placeholder rendering, paging-clause shape, and TRUNCATE wording per backend; both adapters route through `async_dialect_for(config)` instead of hard-coding Postgres syntax. Cross-process W3C `traceparent` propagation through `ProcessManager` ↔ `Subprocess`. Integration-tests CI nightly installs `pdip[integrator,async]` and runs per-backend `connection/sql/<backend>/test_async_connection.py` smoke jobs alongside the existing sync integration suites — every backend exercises the full 8-test adapter shape (connector smoke + 6 adapter methods) instead of just connect/fetch_count, and the workflow is now **verified green end-to-end** for all four backends (Postgres 16, MySQL 8.4, SQL Server 2022, Oracle XE 21c) — running the workflow uncovered a chain of pre-existing bugs in the sync connectors and smoke setUps that this PR also fixes (Driver-18-hardcoded `AsyncMssqlConnector` → discovery; bare-`mysql://` SQLAlchemy URL → `mysql+mysqlconnector://`; bare-path Oracle URL → `?service_name=` for PDB resolution; `sa`/`master`/`Pdi!123456` MSSQL smoke → workflow-provisioned `pdi`/`test_pdi`/`pdi!123456`; `xe`/`pdi` Oracle smoke + sync setUps → workflow-provisioned `test_pdi` PDB + `test_pdi` user; `test_check_schema_and_tables` skips MySQL system schemas that need `PROCESS`). Pre-commit suite is 10 rules. | **What is left on this work-stream**: (a-4 remaining) Span instrumentation of `parallelold/` (multiprocessing) strategy — same span vocabulary already extracted into `strategies/base/span_helpers.py`, only the call-site weaving remains. (a-5 verification) **DONE — green CI run on PR #125 confirms it**. The Async / OTel / 1.0-readiness work is **architecturally + breadth-complete on the SQL backend matrix and CI-verified**; only the parallelold multiprocessing path's spans remain. TDD focus still mandated — ADR-0027 diff-cover 100 % gate + ADR-0026 / ADR-0034 / ADR-0035 / ADR-0036 quality_guard rules (now 10 rules). |
+| Async / OpenTelemetry / 1.0 cut | **All five ADRs Accepted (0032 / 0033 / 0034 / 0035 / 0036); the work-stream is contractually complete on `main` AND foundation-complete across every execution strategy**. ADR-0034 §5 enforcement is now 4 layers, all shipped: drift contract test, `RuleADR0034NoUndocumentedTopLevelPackage` coverage rule, `RuleADR0035PublicApiSignatureSnapshotMatches` signature guard, and the new pair `RuleADR0036DeprecationWarningHasManifestEntry` + `RuleADR0036RemovalRespectsDeprecationCycle` deprecation-cycle guard reading `docs/public-api-deprecations.json`. `pdip.__version__` is exported as the single source of truth for the runtime version (read by the removal-cycle rule). `pdip.observability` exports `get_tracer` / `get_meter` / `inject_context` / `use_context`; `pdip[observability]` and `pdip[async]` extras live in `setup.py`; `Dispatcher.dispatch`, `Integrator.integrate`, `SingleProcessIntegrationExecute`, `parallelthread/operation/{source,target}`, AND now **`parallelold/base/parallel_integration_execute.py`** emit `pdip.cqrs.{command,query}` / `pdip.integrator.job` / `pdip.integrator.source.read` / `pdip.integrator.target.write` spans with their documented attributes via the shared `strategies/base/span_helpers.py`; the async Sql chain dispatches via `_connector_for` to `AsyncPostgresqlConnector` / `AsyncMysqlConnector` / `AsyncMssqlConnector` / `AsyncOracleConnector` (lazy driver imports throughout); `AsyncSqlConnector` ABC has `connect`/`disconnect`/`fetch_count`/`execute`/`fetch_all`/`executemany`; **`AsyncSqlTargetAdapter` and `AsyncSqlSourceAdapter` are fully wired for ALL FOUR backends** — `clear_data` (TRUNCATE), `write_data` (executemany INSERT with column inference + dialect-specific placeholder ladder), `do_target_operation` (truncate-when-flag-set), `get_iterator` (in-memory chunked batches), `get_source_data_with_paging` (LIMIT/OFFSET on Postgres + MySQL, ANSI OFFSET/FETCH NEXT on MSSQL + Oracle), `get_source_data_count`. The dialect helper at `pdip/integrator/connection/types/sql/base/async_sql_dialect.py` centralises identifier quoting, placeholder rendering, paging-clause shape, and TRUNCATE wording per backend; both adapters route through `async_dialect_for(config)` instead of hard-coding Postgres syntax. Cross-process W3C `traceparent` propagation through `ProcessManager` ↔ `Subprocess`. Integration-tests CI nightly installs `pdip[integrator,async]` and runs per-backend `connection/sql/<backend>/test_async_connection.py` smoke jobs alongside the existing sync integration suites — every backend exercises the full 8-test adapter shape (connector smoke + 6 adapter methods) instead of just connect/fetch_count, and the workflow is **verified green end-to-end** for all four backends (Postgres 16, MySQL 8.4, SQL Server 2022, Oracle XE 21c). Pre-commit suite is 10 rules. | **What is left on this work-stream**: nothing on the foundation. (a-4) **DONE — `parallelold/base/parallel_integration_execute.py` now wraps `start_source_data_operation`'s `get_source_data_count` in `pdip.integrator.source.read`, `start_execute_integration_with_source_data`'s `write_data` in `pdip.integrator.target.write`, and `start_execute_integration_with_paging`'s read+write pair in source.read+target.write spans with the documented `pdip.connection.{type,driver}` / `pdip.batch.size` / `pdip.rows.written` attributes via `strategies/base/span_helpers.py`. Pinned by 8 new unit tests under `tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py`.** (a-5 verification) DONE on PR #125. With (a-4) landed, the Async / OTel / 1.0-readiness work is **foundation-complete across every execution strategy** (single-process, parallel-thread, parallel-process/old, async). TDD focus still mandated — ADR-0027 diff-cover 100 % gate + ADR-0026 / ADR-0034 / ADR-0035 / ADR-0036 quality_guard rules (10 rules). |
 
 ## 5. Read this first
 
@@ -122,46 +130,51 @@ rest.
 
 ---
 
-*Last updated 2026-04-26 on `claude/handoff-post-126-refresh-OolIR`
-(bookkeeping refresh — adds #126 to §2's PR chain and
-`claude/handoff-post-125-refresh-OolIR` to §3's post-merge
-artifact list so the trail stays complete after the post-#125
-docs PR landed). `main` is at `4c93c9e`.
-The Async / OTel / 1.0 readiness work-stream remains
-contractually complete with five Accepted ADRs (0032 / 0033 /
-0034 / 0035 / 0036), and the SQL-backend matrix is now
+*Last updated 2026-04-26 on `claude/handoff-state-management-p13Rm`
+(lands the `parallelold/` multiprocessing strategy's ADR-0033 §3
+adapter-call-site spans — the last foundation item on the
+Async / OTel / 1.0 work-stream (a-4) — and refreshes this handoff).
+`main` is at `90debf2`.
+With this branch landed, the Async / OTel / 1.0 readiness
+work-stream is **foundation-complete across every execution
+strategy** (single-process, parallel-thread, parallel-process /
+"old", and async); the five ADRs (0032 / 0033 / 0034 / 0035 /
+0036) all stay Accepted and contractually complete on `main`.
+Concretely:
+`pdip/integrator/integration/types/sourcetotarget/strategies/parallelold/base/parallel_integration_execute.py`
+now wraps `start_source_data_operation` (`get_source_data_count`),
+`start_execute_integration_with_source_data` (`write_data`), and
+`start_execute_integration_with_paging` (paged read + write) in
+the documented `pdip.integrator.source.read` /
+`pdip.integrator.target.write` spans with
+`pdip.connection.{type,driver}` + `pdip.batch.size`
+(+ `pdip.rows.written` on writes) attributes, reusing the shared
+`strategies/base/span_helpers.py::attr_name` / `resolve_driver`
+resolvers so the SQL/BigData/WebService sub-payload walking stays
+consistent with the singleprocess and parallelthread strategies.
+Pinned by 8 new unit tests under
+`tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py`
+covering span name + ordering + attributes (including
+`Limit=None → batch.size=0` and connector-type-driven driver
+resolution) + the `transactionhandler`-decorated
+`start_source_data_operation` entry point (patched
+`DependencyContainer.Instance` so the decorator's
+commit/rollback/close path resolves without a live DI graph).
+SQL-backend async matrix unchanged from #125 — still
 **breadth-complete + CI-verified**: new
 `pdip/integrator/connection/types/sql/base/async_sql_dialect.py`
 centralises per-backend identifier quoting + placeholder ladder
 + paging clause + TRUNCATE wording (asyncpg `$N` / aiomysql
 `%s` / aioodbc `?` / oracledb `:N`; LIMIT/OFFSET vs ANSI
-OFFSET/FETCH NEXT), and both `AsyncSqlSourceAdapter` and
-`AsyncSqlTargetAdapter` route through `async_dialect_for(config)`
-so `write_data` / `clear_data` / `do_target_operation` /
-`get_iterator` / `get_source_data_with_paging` /
-`get_source_data_count` light up real on MySQL / MSSQL / Oracle
-alongside Postgres. Per-backend integration suites
-(`tests/integrationtests/integrator/connection/sql/<backend>/test_async_connection.py`)
-expand from 2 connector smoke tests to the full 8-test shape
-matching the existing asyncpg Postgres test layout, and the
-integration-tests workflow runs all four backends green on the
-PR's self-test trigger. The green-run verification (a-5) also
-surfaced a chain of pre-existing bugs in the sync connectors
-and smoke setUps that this PR fixes — see CHANGELOG `[Unreleased]
-/ Fixed` for the inventory (Driver-18-hardcoded
-`AsyncMssqlConnector`; bare-`mysql://` SQLAlchemy URL;
-bare-path Oracle URL → `?service_name=` for PDB resolution;
-MSSQL / Oracle smoke setUps + sync `test_connection.py` setUps
-aligned to the workflow's provisioned credentials; MySQL
-`test_check_schema_and_tables` skips system schemas that need
-`PROCESS`). Public surface unchanged (no top-level changes;
-`pdip.__version__` + `pdip.observability` exports stable).
-ADR-0034 §5 enforcement complete in **four layers, all shipped**
-(drift / coverage / signature / deprecation-cycle); 100 % unit
-coverage on the canonical `run_tests.py` cell (773 tests, +26
-dialect unit tests); 10 quality_guard rules green. Remaining
-queued work — the `parallelold/` multiprocessing strategy
-spans (a-4) — is the only foundation item left on the
-work-stream. Recorded in §4 Async/OTel/1.0 row. When you change
-anything above, bump this line with the date and the branch
-name so the next reader knows the freshness window at a glance.*
+OFFSET/FETCH NEXT). Public surface unchanged (no top-level
+changes; `pdip.__version__` + `pdip.observability` exports
+stable). ADR-0034 §5 enforcement complete in **four layers, all
+shipped** (drift / coverage / signature / deprecation-cycle);
+100 % unit coverage on the canonical `run_tests.py` cell
+(**781 tests**, +8 parallelold span tests on top of the
+post-#125 baseline of 773); 10 quality_guard rules green.
+**Remaining queued work on the work-stream: none on the
+foundation.** §4 Async/OTel/1.0 row updated to reflect (a-4)
+DONE. When you change anything above, bump this line with the
+date and the branch name so the next reader knows the freshness
+window at a glance.*

--- a/pdip/integrator/integration/types/sourcetotarget/strategies/parallelold/base/parallel_integration_execute.py
+++ b/pdip/integrator/integration/types/sourcetotarget/strategies/parallelold/base/parallel_integration_execute.py
@@ -9,6 +9,7 @@ from injector import inject
 from pandas import DataFrame, notnull
 
 from ...base import IntegrationSourceToTargetExecuteStrategy
+from ...base.span_helpers import attr_name as _attr_name, resolve_driver as _resolve_driver
 from ......domain.base import IntegrationBase
 from .......connection.domain.task import DataQueueTask
 from .......connection.factories import ConnectionSourceAdapterFactory, ConnectionTargetAdapterFactory
@@ -20,6 +21,7 @@ from .......pubsub.publisher import Publisher
 from ........data.decorators import transactionhandler
 from ........dependency import IScoped
 from ........dependency.container import DependencyContainer
+from ........observability import get_tracer
 from ........processing import ProcessManager
 from ........processing.factories import ProcessManagerFactory
 
@@ -209,11 +211,34 @@ class ParallelIntegrationExecute(IntegrationSourceToTargetExecuteStrategy, IScop
         )
         try:
 
+            source_connection_type = operation_integration.Integration.SourceConnections.ConnectionType
             source_adapter = self.connection_source_adapter_factory.get_adapter(
-                connection_type=operation_integration.Integration.SourceConnections.ConnectionType
+                connection_type=source_connection_type
             )
 
-            data_count = source_adapter.get_source_data_count(integration=operation_integration.Integration)
+            tracer = get_tracer("pdip.integrator")
+            with tracer.start_as_current_span(
+                    "pdip.integrator.source.read"
+            ) as read_span:
+                read_span.set_attribute(
+                    "pdip.connection.type",
+                    _attr_name(source_connection_type),
+                )
+                read_span.set_attribute(
+                    "pdip.connection.driver",
+                    _resolve_driver(
+                        operation_integration.Integration.SourceConnections
+                    ),
+                )
+                read_span.set_attribute(
+                    "pdip.batch.size",
+                    operation_integration.Limit
+                    if operation_integration.Limit is not None
+                    else 0,
+                )
+                data_count = source_adapter.get_source_data_count(
+                    integration=operation_integration.Integration
+                )
             if data_count > 0:
                 transmitted_data_count = 0
                 limit = operation_integration.Limit
@@ -413,13 +438,33 @@ class ParallelIntegrationExecute(IntegrationSourceToTargetExecuteStrategy, IScop
                                                    integration: IntegrationBase,
                                                    source_data: any
                                                    ):
+        target_connection_type = integration.TargetConnections.ConnectionType
         target_adapter = self.connection_target_adapter_factory.get_adapter(
-            connection_type=integration.TargetConnections.ConnectionType
+            connection_type=target_connection_type
         )
-        target_adapter.write_data(
-            integration=integration,
-            source_data=source_data
-        )
+        tracer = get_tracer("pdip.integrator")
+        with tracer.start_as_current_span(
+                "pdip.integrator.target.write"
+        ) as write_span:
+            write_span.set_attribute(
+                "pdip.connection.type", _attr_name(target_connection_type)
+            )
+            write_span.set_attribute(
+                "pdip.connection.driver",
+                _resolve_driver(integration.TargetConnections),
+            )
+            write_span.set_attribute(
+                "pdip.batch.size",
+                len(source_data) if source_data is not None else 0,
+            )
+            write_span.set_attribute(
+                "pdip.rows.written",
+                len(source_data) if source_data is not None else 0,
+            )
+            target_adapter.write_data(
+                integration=integration,
+                source_data=source_data
+            )
         return len(source_data)
 
     @func_set_timeout(1800)
@@ -428,19 +473,51 @@ class ParallelIntegrationExecute(IntegrationSourceToTargetExecuteStrategy, IScop
                                               start,
                                               end
                                               ):
+        source_connection_type = integration.SourceConnections.ConnectionType
+        target_connection_type = integration.TargetConnections.ConnectionType
         source_adapter = self.connection_source_adapter_factory.get_adapter(
-            connection_type=integration.SourceConnections.ConnectionType
+            connection_type=source_connection_type
         )
         target_adapter = self.connection_target_adapter_factory.get_adapter(
-            connection_type=integration.TargetConnections.ConnectionType
+            connection_type=target_connection_type
         )
-        source_data = source_adapter.get_source_data_with_paging(
-            integration=integration,
-            start=start,
-            end=end
-        )
-        target_adapter.write_data(
-            integration=integration,
-            source_data=source_data
-        )
+        tracer = get_tracer("pdip.integrator")
+        with tracer.start_as_current_span(
+                "pdip.integrator.source.read"
+        ) as read_span:
+            read_span.set_attribute(
+                "pdip.connection.type", _attr_name(source_connection_type)
+            )
+            read_span.set_attribute(
+                "pdip.connection.driver",
+                _resolve_driver(integration.SourceConnections),
+            )
+            read_span.set_attribute("pdip.batch.size", end - start)
+            source_data = source_adapter.get_source_data_with_paging(
+                integration=integration,
+                start=start,
+                end=end
+            )
+        with tracer.start_as_current_span(
+                "pdip.integrator.target.write"
+        ) as write_span:
+            write_span.set_attribute(
+                "pdip.connection.type", _attr_name(target_connection_type)
+            )
+            write_span.set_attribute(
+                "pdip.connection.driver",
+                _resolve_driver(integration.TargetConnections),
+            )
+            write_span.set_attribute(
+                "pdip.batch.size",
+                len(source_data) if source_data is not None else 0,
+            )
+            write_span.set_attribute(
+                "pdip.rows.written",
+                len(source_data) if source_data is not None else 0,
+            )
+            target_adapter.write_data(
+                integration=integration,
+                source_data=source_data
+            )
         return len(source_data)

--- a/tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py
+++ b/tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py
@@ -1,0 +1,329 @@
+"""Unit tests for ``ParallelIntegrationExecute`` — the multiprocessing
+source-to-target strategy ("parallelold").
+
+These tests target the ADR-0033 §3 adapter-call-site span
+instrumentation that the strategy emits at three call sites:
+
+* ``start_source_data_operation`` — wraps the
+  ``source_adapter.get_source_data_count`` call in a
+  ``pdip.integrator.source.read`` span,
+* ``start_execute_integration_with_source_data`` — wraps the
+  ``target_adapter.write_data`` call in a
+  ``pdip.integrator.target.write`` span,
+* ``start_execute_integration_with_paging`` — wraps the
+  ``source_adapter.get_source_data_with_paging`` call in a
+  ``pdip.integrator.source.read`` span and the subsequent
+  ``target_adapter.write_data`` call in a
+  ``pdip.integrator.target.write`` span.
+
+The strategy is otherwise covered by the integration-tests suite
+because the orchestration paths boot ``multiprocessing.Manager`` /
+``ProcessManager`` and require a real broker — see
+``.coveragerc`` ``omit`` list. The span call sites do not require
+any of that machinery and so are exercised here as plain unit
+tests with mocked factories and a recording tracer.
+"""
+
+# Stub pandas/func_timeout before any ``pdip.integrator.*`` import.
+from tests.unittests.integrator import _stub_pandas  # noqa: F401, E402
+
+import queue  # noqa: E402
+from unittest import TestCase  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from pdip.integrator.integration.types.sourcetotarget.strategies.parallelold.base.parallel_integration_execute import (  # noqa: E402
+    ParallelIntegrationExecute,
+)
+from pdip.integrator.pubsub.base import ChannelQueue  # noqa: E402
+
+
+_MODULE_PATH = (
+    "pdip.integrator.integration.types.sourcetotarget"
+    ".strategies.parallelold.base"
+    ".parallel_integration_execute.get_tracer"
+)
+
+
+class _SpanRecorder:
+    def __init__(self):
+        self.attributes = {}
+        self.entered = 0
+        self.exited = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        return False
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class _TracerRecorder:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name):
+        span = _SpanRecorder()
+        span.name = name
+        self.spans.append(span)
+        return span
+
+
+def _build_subject(source_adapter=None, target_adapter=None):
+    source_factory = MagicMock(name="source_factory")
+    source_factory.get_adapter.return_value = (
+        source_adapter if source_adapter is not None else MagicMock()
+    )
+    target_factory = MagicMock(name="target_factory")
+    target_factory.get_adapter.return_value = (
+        target_adapter if target_adapter is not None else MagicMock()
+    )
+    process_manager_factory = MagicMock(name="process_manager_factory")
+    subject = ParallelIntegrationExecute(
+        process_manager_factory=process_manager_factory,
+        connection_source_adapter_factory=source_factory,
+        connection_target_adapter_factory=target_factory,
+    )
+    return subject
+
+
+def _build_operation(source_type="SQL", limit=10, process_count=1, data_count=0):
+    operation = MagicMock(name="operation_integration")
+    operation.Limit = limit
+    operation.ProcessCount = process_count
+    operation.Integration.SourceConnections.ConnectionType = source_type
+    return operation
+
+
+def _build_integration(source_type="SQL", target_type="SQL"):
+    integration = MagicMock(name="integration")
+    integration.SourceConnections.ConnectionType = source_type
+    integration.TargetConnections.ConnectionType = target_type
+    return integration
+
+
+class StartSourceDataOperationEmitsSourceReadSpan(TestCase):
+    """``start_source_data_operation`` opens one
+    ``pdip.integrator.source.read`` span around ``get_source_data_count``.
+    """
+
+    def setUp(self):
+        self.channel = ChannelQueue(queue.Queue())
+
+    def _run(self, source, operation, data_queue=None, data_result_queue=None):
+        subject = _build_subject(source_adapter=source)
+        tracer = _TracerRecorder()
+        # ``start_source_data_operation`` is wrapped by
+        # ``@transactionhandler``, which calls
+        # ``DependencyContainer.Instance.get(RepositoryProvider)`` for
+        # commit/rollback/close. Replace the global container with a
+        # mock so the decorator does not need a live DI graph.
+        fake_container = MagicMock(name="dependency_container")
+        with patch(
+            "pdip.data.decorators.transaction_handler.DependencyContainer.Instance",
+            fake_container,
+        ), patch(_MODULE_PATH, return_value=tracer):
+            subject.start_source_data_operation(
+                sub_process_id=0,
+                channel=self.channel,
+                operation_integration=operation,
+                data_queue=data_queue if data_queue is not None else queue.Queue(),
+                data_result_queue=data_result_queue
+                if data_result_queue is not None
+                else queue.Queue(),
+            )
+        return tracer
+
+    def test_opens_pdip_integrator_source_read_span_around_get_source_data_count(self):
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_count.return_value = 0
+        operation = _build_operation(source_type="SQL", limit=25, process_count=1)
+
+        tracer = self._run(source, operation)
+
+        read_spans = [s for s in tracer.spans if s.name == "pdip.integrator.source.read"]
+        self.assertEqual(len(read_spans), 1)
+        span = read_spans[0]
+        self.assertEqual(span.entered, 1)
+        self.assertEqual(span.exited, 1)
+        self.assertEqual(span.attributes.get("pdip.connection.type"), "SQL")
+        self.assertEqual(span.attributes.get("pdip.batch.size"), 25)
+        # Best-effort driver — MagicMock chain falls back to "".
+        self.assertEqual(span.attributes.get("pdip.connection.driver"), "")
+        source.get_source_data_count.assert_called_once_with(
+            integration=operation.Integration
+        )
+
+    def test_batch_size_is_zero_when_limit_is_none(self):
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_count.return_value = 0
+        operation = _build_operation(source_type="SQL", limit=None, process_count=1)
+
+        tracer = self._run(source, operation)
+
+        span = [s for s in tracer.spans if s.name == "pdip.integrator.source.read"][0]
+        self.assertEqual(span.attributes.get("pdip.batch.size"), 0)
+
+    def test_resolves_driver_from_sql_connector_type_when_present(self):
+        from pdip.integrator.connection.domain.enums import (
+            ConnectionTypes,
+            ConnectorTypes,
+        )
+
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_count.return_value = 0
+        operation = MagicMock(name="operation_integration")
+        operation.Limit = 5
+        operation.ProcessCount = 1
+        operation.Integration.SourceConnections.ConnectionType = ConnectionTypes.Sql
+        operation.Integration.SourceConnections.Sql.Connection.ConnectorType = (
+            ConnectorTypes.POSTGRESQL
+        )
+        operation.Integration.SourceConnections.BigData = None
+        operation.Integration.SourceConnections.WebService = None
+
+        tracer = self._run(source, operation)
+
+        span = [s for s in tracer.spans if s.name == "pdip.integrator.source.read"][0]
+        self.assertEqual(span.attributes.get("pdip.connection.type"), "Sql")
+        self.assertEqual(span.attributes.get("pdip.connection.driver"), "POSTGRESQL")
+
+
+class StartExecuteIntegrationWithSourceDataEmitsTargetWriteSpan(TestCase):
+    """``start_execute_integration_with_source_data`` opens one
+    ``pdip.integrator.target.write`` span around ``write_data``.
+    """
+
+    def test_opens_target_write_span_with_rows_written_matching_source_data_length(self):
+        target = MagicMock(name="target_adapter")
+        subject = _build_subject(target_adapter=target)
+        integration = _build_integration(target_type="QUEUE")
+        source_data = [1, 2, 3, 4]
+
+        tracer = _TracerRecorder()
+        with patch(_MODULE_PATH, return_value=tracer):
+            result = subject.start_execute_integration_with_source_data(
+                integration=integration,
+                source_data=source_data,
+            )
+
+        self.assertEqual(result, 4)
+        write_spans = [
+            s for s in tracer.spans if s.name == "pdip.integrator.target.write"
+        ]
+        self.assertEqual(len(write_spans), 1)
+        span = write_spans[0]
+        self.assertEqual(span.entered, 1)
+        self.assertEqual(span.exited, 1)
+        self.assertEqual(span.attributes.get("pdip.connection.type"), "QUEUE")
+        self.assertEqual(span.attributes.get("pdip.connection.driver"), "")
+        self.assertEqual(span.attributes.get("pdip.batch.size"), 4)
+        self.assertEqual(span.attributes.get("pdip.rows.written"), 4)
+        target.write_data.assert_called_once_with(
+            integration=integration, source_data=source_data
+        )
+
+    def test_resolves_driver_from_target_connector_type_when_present(self):
+        from pdip.integrator.connection.domain.enums import (
+            ConnectionTypes,
+            ConnectorTypes,
+        )
+
+        target = MagicMock(name="target_adapter")
+        subject = _build_subject(target_adapter=target)
+        integration = MagicMock(name="integration")
+        integration.TargetConnections.ConnectionType = ConnectionTypes.Sql
+        integration.TargetConnections.Sql.Connection.ConnectorType = (
+            ConnectorTypes.MYSQL
+        )
+        integration.TargetConnections.BigData = None
+        integration.TargetConnections.WebService = None
+
+        tracer = _TracerRecorder()
+        with patch(_MODULE_PATH, return_value=tracer):
+            subject.start_execute_integration_with_source_data(
+                integration=integration,
+                source_data=[1, 2],
+            )
+
+        span = [
+            s for s in tracer.spans if s.name == "pdip.integrator.target.write"
+        ][0]
+        self.assertEqual(span.attributes.get("pdip.connection.driver"), "MYSQL")
+
+
+class StartExecuteIntegrationWithPagingEmitsBothSpans(TestCase):
+    """``start_execute_integration_with_paging`` opens a
+    ``pdip.integrator.source.read`` span around the paged read and a
+    ``pdip.integrator.target.write`` span around the subsequent write.
+    """
+
+    def test_opens_source_read_then_target_write_in_order(self):
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_with_paging.return_value = [1, 2, 3]
+        target = MagicMock(name="target_adapter")
+        subject = _build_subject(source_adapter=source, target_adapter=target)
+        integration = _build_integration(source_type="SQL", target_type="SQL")
+
+        tracer = _TracerRecorder()
+        with patch(_MODULE_PATH, return_value=tracer):
+            result = subject.start_execute_integration_with_paging(
+                integration=integration, start=10, end=40
+            )
+
+        self.assertEqual(result, 3)
+        # Span ordering matters: read first, then write.
+        names = [s.name for s in tracer.spans]
+        self.assertEqual(
+            names,
+            ["pdip.integrator.source.read", "pdip.integrator.target.write"],
+        )
+
+    def test_source_read_span_carries_paging_window_as_batch_size(self):
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_with_paging.return_value = []
+        target = MagicMock(name="target_adapter")
+        subject = _build_subject(source_adapter=source, target_adapter=target)
+        integration = _build_integration(source_type="SQL", target_type="SQL")
+
+        tracer = _TracerRecorder()
+        with patch(_MODULE_PATH, return_value=tracer):
+            subject.start_execute_integration_with_paging(
+                integration=integration, start=20, end=70
+            )
+
+        read_span = [
+            s for s in tracer.spans if s.name == "pdip.integrator.source.read"
+        ][0]
+        # batch.size mirrors the paging window (end - start) per the
+        # parallelthread reference implementation.
+        self.assertEqual(read_span.attributes.get("pdip.batch.size"), 50)
+        self.assertEqual(read_span.attributes.get("pdip.connection.type"), "SQL")
+        self.assertEqual(read_span.attributes.get("pdip.connection.driver"), "")
+
+    def test_target_write_span_records_rows_written_from_returned_page(self):
+        source = MagicMock(name="source_adapter")
+        source.get_source_data_with_paging.return_value = [1, 2]
+        target = MagicMock(name="target_adapter")
+        subject = _build_subject(source_adapter=source, target_adapter=target)
+        integration = _build_integration(source_type="SQL", target_type="QUEUE")
+
+        tracer = _TracerRecorder()
+        with patch(_MODULE_PATH, return_value=tracer):
+            subject.start_execute_integration_with_paging(
+                integration=integration, start=0, end=10
+            )
+
+        write_span = [
+            s for s in tracer.spans if s.name == "pdip.integrator.target.write"
+        ][0]
+        self.assertEqual(write_span.attributes.get("pdip.connection.type"), "QUEUE")
+        self.assertEqual(write_span.attributes.get("pdip.batch.size"), 2)
+        self.assertEqual(write_span.attributes.get("pdip.rows.written"), 2)
+        target.write_data.assert_called_once_with(
+            integration=integration, source_data=[1, 2]
+        )


### PR DESCRIPTION
## Summary

Lands the **last foundation item** on the Async / OTel / 1.0 work-stream — span instrumentation of the `parallelold/` (multiprocessing) execution strategy (ADR-0032 §3 follow-up **a-4**) — and refreshes `docs/handoff.md` to reflect the new state.

`ParallelIntegrationExecute` now wraps its three `ConnectionSourceAdapter` / `ConnectionTargetAdapter` call sites in the documented ADR-0033 §3 spans:

| Method | Span | Notes |
|---|---|---|
| `start_source_data_operation` | `pdip.integrator.source.read` | Around `get_source_data_count`. `pdip.batch.size = Limit if not None else 0`. |
| `start_execute_integration_with_source_data` | `pdip.integrator.target.write` | Around `write_data`. `pdip.batch.size` + `pdip.rows.written` mirror the source-data length. |
| `start_execute_integration_with_paging` | `pdip.integrator.source.read` then `pdip.integrator.target.write` | Read span carries `batch.size = end - start`; write span carries `rows.written = len(source_data)`. |

All three sites reuse the shared `strategies/base/span_helpers.py::{attr_name, resolve_driver}` resolvers, keeping the SQL / BigData / WebService sub-payload walking byte-for-byte consistent with the existing `singleprocess` and `parallelthread` instrumentation.

With this PR landed, the Async / OTel / 1.0 readiness work-stream is **foundation-complete across every execution strategy** (single-process, parallel-thread, parallel-process / "old", async).

### Files changed

- `pdip/integrator/integration/types/sourcetotarget/strategies/parallelold/base/parallel_integration_execute.py` — adds the three spans + `_attr_name` / `_resolve_driver` / `get_tracer` imports.
- `tests/unittests/integrator/integration/parallelold/test_parallel_integration_execute_spans.py` (new) — 8 tests covering span name, ordering, attributes (including `Limit=None → batch.size=0` and connector-type-driven driver resolution), and the `transactionhandler`-decorated `start_source_data_operation` entry point.
- `tests/unittests/integrator/integration/parallelold/__init__.py` (new).
- `CHANGELOG.md` — `[Unreleased] / Added` entry inserted ahead of the existing async-chain entry.
- `docs/handoff.md` — §2 PR chain (+ #127), §3 post-merge artifact list (+ `claude/handoff-post-126-refresh-OolIR`) and active-branch line, §4 Async/OTel/1.0 row (a-4 DONE), and the trailer (date / branch / `main @ 90debf2` / **781 tests**).

### Notes

- `parallelold/*` is in `.coveragerc` `omit` per the integration-test policy (multiprocessing-bound + needs a real broker), so the new lines are not in the coverage score. The new tests still prove span emission + attribute correctness as plain unit tests by patching `DependencyContainer.Instance` (so the `@transactionhandler` wrapper resolves without a live DI graph) and `get_tracer` (recording tracer).
- Public surface unchanged. No top-level package or signature changes; ADR-0034 / 0035 / 0036 guards stay green.

## Test plan

- [x] `python run_tests.py` → **781 / 781** unit tests green (773 baseline + 8 new).
- [x] `python -m coverage run run_tests.py && python -m coverage report` → **100 %** maintained.
- [x] `python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --fail-under=100` → no lines with coverage information in this diff (parallelold is omitted), gate passes vacuously.
- [x] `pre-commit run --files <changed-files>` → all hooks pass (10 quality_guard rules + flake8 + whitespace / EOL / merge-conflict / large-file).
- [x] `python -m unittest tests.unittests.quality_guard.test_conventions -v` → 10 / 10 rules pass.
- [ ] Integration-tests workflow: not exercised by this PR (parallelold path runs in integration tests against real backends; the span instrumentation is a non-functional addition that follows the same pattern already CI-verified for `singleprocess` and `parallelthread/operation/{source,target}` on PR #125).

https://claude.ai/code/session_01H3uGeMdkGZ9XKj2TpGa3jh

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3uGeMdkGZ9XKj2TpGa3jh)_